### PR TITLE
Revert some formatting changes

### DIFF
--- a/fmp_server.py
+++ b/fmp_server.py
@@ -46,8 +46,8 @@ class FmpRequestHandler(PatRequestHandler):
        JP: レイヤダウン返答
        TR: Layer down response
        """
-
         self.session.layer_down(layer_id)
+
         if self.session.layer == 1:  # Gate
             user = pati.LayerUserInfo()
             user.capcom_id = pati.String(self.session.capcom_id)
@@ -56,7 +56,6 @@ class FmpRequestHandler(PatRequestHandler):
 
             data = pati.lp2_string(self.session.capcom_id)
             data += user.pack()
-
             self.server.layer_broadcast(self.session, PatID4.NtcLayerIn,
                                         data, seq)
 
@@ -76,7 +75,6 @@ class FmpRequestHandler(PatRequestHandler):
          - Online > Settings > Profile
          - Online > Settings > Status Indicator
         """
-
         offset, length = struct.unpack_from(">IH", data)
         binary = pati.unpack_lp2_string(data, 4)
         self.session.hunter_info.unpack(data[6:], length, offset)
@@ -92,7 +90,6 @@ class FmpRequestHandler(PatRequestHandler):
 
         TODO: Properly handle binary settings.
         """
-
         self.send_packet(PatID4.AnsUserBinarySet, b"", seq)
 
     def recvReqUserBinaryNotice(self, packet_id, data, seq):
@@ -101,32 +98,25 @@ class FmpRequestHandler(PatRequestHandler):
         ID: 66320100
         JP: ユーザ表示用バイナリ通知要求
         TR: Binary notification request for user display
-
         """
-
         unk1, = struct.unpack_from(">B", data)
         capcom_id = pati.unpack_lp2_string(data, 1)
         offset, length = struct.unpack_from(">II", data, 3+len(capcom_id))
-
         self.sendAnsUserBinaryNotice(unk1, capcom_id, offset, length, seq)
 
     def sendAnsUserBinaryNotice(self, unk1, capcom_id, offset, length, seq):
         """AnsUserBinaryNotice packet.
 
-       ID: 66320200
-       JP: ユーザ表示用バイナリ通知返答
-       TR: Binary notification reply for user display
-       """
-
+        ID: 66320200
+        JP: ユーザ表示用バイナリ通知返答
+        TR: Binary notification reply for user display
+        """
         data = struct.pack(">B", unk1)
         data += pati.lp2_string(self.session.capcom_id)
         data += struct.pack(">I", 0)
-
         data += pati.lp2_string(self.session.hunter_info.pack())
-
-        self.server.layer_broadcast(self.session,
-                                    PatID4.NtcUserBinaryNotice, data, seq)
-
+        self.server.layer_broadcast(self.session, PatID4.NtcUserBinaryNotice,
+                                    data, seq)
         self.send_packet(PatID4.AnsUserBinaryNotice, b"", seq)
 
     def recvReqLayerUserList(self, packet_id, data, seq):
@@ -147,7 +137,6 @@ class FmpRequestHandler(PatRequestHandler):
         JP: レイヤ同期ユーザリスト返答
         TR: Layer sync user list response
         """
-
         players = self.session.get_layer_players()
         count = len(players)
         data = struct.pack(">I", count)
@@ -168,7 +157,6 @@ class FmpRequestHandler(PatRequestHandler):
         JP: レイヤのホスト者要求
         TR: Layer host request
         """
-
         self.sendAnsLayerHost(data, seq)
 
     def sendAnsLayerHost(self, unk_data, seq):
@@ -178,18 +166,15 @@ class FmpRequestHandler(PatRequestHandler):
         JP: レイヤのホスト者返答
         TR: Layer host response
         """
-
         city = self.session.get_city()
         leader = city.leader
         assert leader != self.session
 
         leader_handler = self.server.get_pat_handler(leader)
 
-        self.server.debug("ReqLayerHost: Req ({}, {})  Host ({}, {})".
-                          format(self.session.capcom_id,
-                                 self.session.hunter_name,
-                                 leader.capcom_id,
-                                 leader.hunter_name))
+        self.server.debug("ReqLayerHost: Req ({}, {})  Host ({}, {})".format(
+            self.session.capcom_id, self.session.hunter_name,
+            leader.capcom_id, leader.hunter_name))
 
         data = unk_data
         data += pati.lp2_string(leader.capcom_id)
@@ -217,23 +202,19 @@ class FmpRequestHandler(PatRequestHandler):
         JP: レイヤゲームポジション受信通知
         TR: Layer game position reception notification
         """
-
         self.sendNtcLayerUserPosition(data, seq)
 
     def sendNtcLayerUserPosition(self, fo, seq):
         """NtcLayerBinary packet.
 
-       ID: 64711000
-       JP: レイヤゲームポジション通知
-       TR: Layer game position notification
-       """
-
+        ID: 64711000
+        JP: レイヤゲームポジション通知
+        TR: Layer game position notification
+        """
         data = pati.lp2_string(self.session.capcom_id)
         data += fo
-
-        self.server.layer_broadcast(self.session,
-                                    PatID4.NtcLayerUserPosition, data,
-                                    seq)
+        self.server.layer_broadcast(self.session, PatID4.NtcLayerUserPosition,
+                                    data, seq)
 
     def recvNtcLayerBinary(self, packet_id, data, seq):
         """NtcLayerBinary packet.
@@ -242,7 +223,6 @@ class FmpRequestHandler(PatRequestHandler):
         JP: レイヤユーザ用バイナリ通知
         TR: Binary notifications for layer users
         """
-
         sender_blank = pati.LayerUserInfo.unpack(data)
         unk_data = data[len(sender_blank.pack()):]
         self.sendNtcLayerBinary(unk_data, seq)
@@ -254,7 +234,6 @@ class FmpRequestHandler(PatRequestHandler):
         JP: レイヤユーザ用バイナリ送信
         TR: Binary transmission for layer users
         """
-
         sender = pati.LayerBinaryInfo()
         sender.unk_long_0x01 = pati.Long(0x12345678)
         sender.capcom_id = pati.String(self.session.capcom_id)
@@ -277,16 +256,14 @@ class FmpRequestHandler(PatRequestHandler):
         JP: レイヤユーザ用バイナリ通知 (相手指定)
         TR: Binary notification for layer users (specify the other party)
         """
-
         partner = pati.unpack_lp2_string(data)
-        partner_size = len(partner)+2
+        partner_size = len(partner) + 2
         binary_info = pati.LayerBinaryInfo.unpack(data, partner_size)
         unk_data = data[partner_size+len(binary_info.pack()):]
 
         self.server.debug("NtcLayerBinary2: From ({}, {})\n{}".format(
             self.session.capcom_id, self.session.hunter_name,
             hexdump(unk_data)))
-
         self.sendNtcLayerBinary2(partner, unk_data, seq)
 
     def sendNtcLayerBinary2(self, partner, unk_data, seq):
@@ -296,10 +273,9 @@ class FmpRequestHandler(PatRequestHandler):
         JP: レイヤユーザ用バイナリ通知 (相手指定)
         TR: Binary transmission for layer users (specify the other party)
         """
-
         city = self.session.get_city()
-        partner_session = next(
-            p for p in city.players if p.capcom_id == partner)
+        partner_session = next(p for p in city.players
+                               if p.capcom_id == partner)
         if partner_session is None:
             return
 
@@ -316,8 +292,7 @@ class FmpRequestHandler(PatRequestHandler):
         if partner_pat_handler is None:
             return
 
-        partner_pat_handler.send_packet(PatID4.NtcLayerBinary2, data,
-                                        seq)
+        partner_pat_handler.send_packet(PatID4.NtcLayerBinary2, data, seq)
 
     def recvReqLayerUp(self, packet_id, data, seq):
         """ReqLayerUp packet.
@@ -329,7 +304,6 @@ class FmpRequestHandler(PatRequestHandler):
         Sent by the game when leaving the gate via the entrance:
          - Relocate > Select Server
         """
-
         if self.session.layer == 2:
             city = self.session.get_city()
             if city.leader == self.session:
@@ -339,9 +313,8 @@ class FmpRequestHandler(PatRequestHandler):
                 city.leader = None
 
             ntc_data = pati.lp2_string(self.session.capcom_id)
-            self.server.layer_broadcast(self.session,
-                                        PatID4.NtcLayerOut, ntc_data,
-                                        seq)
+            self.server.layer_broadcast(self.session, PatID4.NtcLayerOut,
+                                        ntc_data, seq)
         self.sendAnsLayerUp(data, seq)
 
     def recvReqUserSearchInfoMine(self, packet_id, data, seq):
@@ -351,7 +324,6 @@ class FmpRequestHandler(PatRequestHandler):
         JP: ユーザ検索データ要求(自分)
         TR: User search data request (self)
         """
-
         search_info = pati.UserSearchInfo.unpack(data)
         self.server.debug("SearchInfo: {!r}".format(search_info))
         self.sendAnsUserSearchInfoMine(search_info, seq)
@@ -366,20 +338,18 @@ class FmpRequestHandler(PatRequestHandler):
         TODO: Figure out what to do with it.
         Maybe prevent the same profile to be connected twice simultaneously.
         """
-
         info_mine_0x0f = int(hash(self.session.capcom_id)) & 0xffffffff
-        info_mine_0x10 = int(
-            hash(self.session.capcom_id[::-1])) & 0xffffffff
+        info_mine_0x10 = int(hash(self.session.capcom_id[::-1])) & 0xffffffff
 
-        self.server.debug(
-            "SearchInfoMine: {:08X} {:08X}".format(info_mine_0x0f,
-                                                   info_mine_0x10))
+        self.server.debug("SearchInfoMine: {:08X} {:08X}".format(
+            info_mine_0x0f, info_mine_0x10))
 
         search_info = pati.UserSearchInfo()
 
-        # This fields are used to identify a user. Specifically when a
-        # client is deserializing data from the packets `NtcLayerBinary` and
-        # `NtcLayerBinary2` TODO: Proper field value and name
+        # This fields are used to identify a user.
+        # Specifically when a client is deserializing data from the packets
+        # `NtcLayerBinary` and `NtcLayerBinary2`
+        # TODO: Proper field value and name
         search_info.info_mine_0x0f = pati.Long(info_mine_0x0f)
         search_info.info_mine_0x10 = pati.Long(info_mine_0x10)
         data = search_info.pack()
@@ -414,8 +384,7 @@ class FmpRequestHandler(PatRequestHandler):
             info = pati.CircleInfo()
             info.index = pati.Long(i+1)
             info.leader_capcom_id = pati.String(circle.leader.capcom_id)
-            info.has_password = pati.Byte(
-                1 if circle.has_password() else 0)
+            info.has_password = pati.Byte(int(circle.has_password()))
             info.team_size = pati.Long(circle.capacity)
 
             if circle.remarks is not None:
@@ -444,18 +413,19 @@ class FmpRequestHandler(PatRequestHandler):
         TR: Circle creation request
         """
         circle_info = pati.CircleInfo.unpack(data)
-        circle_optional_fields = pati.unpack_optional_fields(data,
-                                                             len(circle_info.pack()))
+        circle_optional_fields = pati.unpack_optional_fields(
+            data, len(circle_info.pack()))
         # Extra fields
         #  - field_id 0x01: Party capacity
         #  - field_id 0x02: Quest ID
-        self.server.debug("CircleCreate: {!r}, {!r}".format(circle_info,
-                                                            circle_optional_fields))
+        self.server.debug("CircleCreate: {!r}, {!r}".format(
+                          circle_info, circle_optional_fields))
 
         city = self.session.get_city()
         (circle, circle_index) = city.get_first_empty_circle()
 
-        assert circle is not None  # TODO: Transmit error when no slot available
+        # TODO: Transmit error when no slot available
+        assert circle is not None
 
         circle.leader = self.session
         circle.players.append(self.session)
@@ -482,29 +452,24 @@ class FmpRequestHandler(PatRequestHandler):
         circle_info.team_size = pati.Long(circle.get_capacity())
         circle_info.unk_long_0x0a = pati.Long(5)
         circle_info.unk_long_0x0b = pati.Long(6)
-        circle_info.unk_long_0x0c = \
-            pati.Long(
-                circle_index+1)  # TODO: RE what exactly is this field
-        circle_info.leader_capcom_id = pati.String(
-            self.session.capcom_id)
+        # TODO: RE what exactly is this field
+        circle_info.unk_long_0x0c = pati.Long(circle_index+1)
+        circle_info.leader_capcom_id = pati.String(self.session.capcom_id)
         circle_info.unk_byte_0x0f = pati.Byte(0)  # Is Full? VERIFY this
 
         # Notify every city's player
-        ntc_circle_list_layer_create_data = struct.pack(">I",
-                                                        circle_index+1)
+        ntc_circle_list_layer_create_data = struct.pack(">I", circle_index+1)
         ntc_circle_list_layer_create_data += circle_info.pack()
         ntc_circle_list_layer_create_data += pati.pack_optional_fields(
             circle_optional_fields)
 
         for city_player in city.players:
-            city_player_handler = self.server.get_pat_handler(
-                city_player)
+            city_player_handler = self.server.get_pat_handler(city_player)
             city_player_handler.send_packet(
                 PatID4.NtcCircleListLayerCreate,
                 ntc_circle_list_layer_create_data, seq)
 
-        self.sendAnsCircleCreate(circle_index+1, circle_optional_fields,
-                                 seq)
+        self.sendAnsCircleCreate(circle_index+1, circle_optional_fields, seq)
 
     def sendAnsCircleCreate(self, circle, extra, seq):
         """AnsCircleCreate packet.
@@ -514,7 +479,6 @@ class FmpRequestHandler(PatRequestHandler):
         TR: Circle creation response
         """
         data = struct.pack(">I", circle)
-
         self.send_packet(PatID4.AnsCircleCreate, data, seq)
 
     def recvReqCircleMatchOptionSet(self, packet_id, data, seq):
@@ -535,12 +499,10 @@ class FmpRequestHandler(PatRequestHandler):
         JP: マッチングオプション設定返答
         TR: Match option settings response
         """
-
         circle = self.session.get_circle()
         options.capcom_id = pati.String(self.session.capcom_id)
         options.hunter_name = pati.String(self.session.hunter_name)
-        options.player_index = pati.Byte(
-            circle.players.index(self.session)+1)
+        options.player_index = pati.Byte(circle.players.index(self.session)+1)
         ntc_data = options.pack()
 
         for circle_player in circle.players:
@@ -548,8 +510,8 @@ class FmpRequestHandler(PatRequestHandler):
                 continue
 
             pat_handler = self.server.get_pat_handler(circle_player)
-            pat_handler.send_packet(PatID4.NtcCircleMatchOptionSet,
-                                    ntc_data, seq)
+            pat_handler.send_packet(PatID4.NtcCircleMatchOptionSet, ntc_data,
+                                    seq)
 
         self.send_packet(PatID4.AnsCircleMatchOptionSet, b"", seq)
 
@@ -574,7 +536,6 @@ class FmpRequestHandler(PatRequestHandler):
         JP: サークルデータ取得返答
         TR: Circle data acquisition reply
         """
-
         data = struct.pack(">I", circle_index)
 
         city = self.session.get_city()
@@ -611,8 +572,8 @@ class FmpRequestHandler(PatRequestHandler):
             (2, circle.questId)
         ]
 
-        self.server.debug("AnsCircleInfo: {!r} {!r}".format(circle_info,
-                                                            optional_fields))
+        self.server.debug("AnsCircleInfo: {!r} {!r}".format(
+                          circle_info, optional_fields))
 
         data += circle_info.pack()
         data += pati.pack_optional_fields(optional_fields)
@@ -626,10 +587,10 @@ class FmpRequestHandler(PatRequestHandler):
         JP: サークルイン要求
         TR: Circle-in request
         """
-
         circle_index, = struct.unpack_from(">I", data)
 
-        # In this circle info, the only possible field filled are the: unk_long_0x0b, has_password, password
+        # In this circle info, the only possible field filled are:
+        # unk_long_0x0b, has_password, password
         circle_info = pati.CircleInfo.unpack(data, 4)
 
         city = self.session.get_city()
@@ -655,10 +616,9 @@ class FmpRequestHandler(PatRequestHandler):
         """AnsCircleJoin packet.
 
         ID: 65030200
-        JP:  	サークルイン返答
+        JP: サークルイン返答
         TR: Circle-in reply
         """
-
         data = struct.pack(">IB", circle_index, unk)
         self.send_packet(PatID4.AnsCircleJoin, data, seq)
 
@@ -694,7 +654,6 @@ class FmpRequestHandler(PatRequestHandler):
         JP: サークル同期ユーザリスト要求
         TR: Circle sync user list request
         """
-
         # Ignore packet data
         self.sendAnsCircleUserList(seq)
 
@@ -705,7 +664,6 @@ class FmpRequestHandler(PatRequestHandler):
         JP: サークル同期ユーザリスト返答
         TR: Circle sync user list reply
         """
-
         circle = self.session.get_circle()
 
         data = struct.pack(">I", circle.get_population())
@@ -739,15 +697,16 @@ class FmpRequestHandler(PatRequestHandler):
         JP: サークルのホスト者返答
         TR: Circle host response
         """
-
         city = self.session.get_city()
         circle = city.circles[circle_index-1]
 
-        leader_index = 0  # next(i for i in range(0, circle.get_population()) if circle.players[i] == circle.leader)
+        leader_index = 0
+        # leader_index = next(i for i in range(0, circle.get_population())
+        #                     if circle.players[i] == circle.leader)
         assert leader_index is not None
 
         # TODO: Verify this field
-        unk1 = leader_index+1
+        unk1 = leader_index + 1
 
         data = struct.pack(">IB", circle_index, unk1)
         data += pati.lp2_string(circle.leader.capcom_id)
@@ -759,8 +718,8 @@ class FmpRequestHandler(PatRequestHandler):
 
             circle_player_pat_handler = \
                 self.server.get_pat_handler(circle_player)
-            circle_player_pat_handler.send_packet(PatID4.NtcCircleHost,
-                                                  data, seq)
+            circle_player_pat_handler.send_packet(PatID4.NtcCircleHost, data,
+                                                  seq)
 
         self.send_packet(PatID4.AnsCircleHost, data, seq)
 
@@ -771,7 +730,6 @@ class FmpRequestHandler(PatRequestHandler):
         JP: サークルバイナリ通知
         TR: Circle binary notification
         """
-
         circle_index, = struct.unpack_from(">I", data)
         sender_blank = pati.LayerUserInfo.unpack(data, 4)
         unk_data = data[len(sender_blank.pack())+4:]
@@ -784,7 +742,6 @@ class FmpRequestHandler(PatRequestHandler):
         JP: サークルバイナリ送信
         TR: Circle binary transmission
         """
-
         sender = pati.LayerBinaryInfo()
         sender.unk_long_0x01 = pati.Long(0x12345678)
         sender.capcom_id = pati.String(self.session.capcom_id)
@@ -819,7 +776,6 @@ class FmpRequestHandler(PatRequestHandler):
         JP: サークルバイナリ通知 (相手指定)
         TR: Circle binary notification (specified by the other party)
         """
-
         circle_index, = struct.unpack_from(">I", data)
         partner = pati.unpack_lp2_string(data, 4)
         partner_size = len(partner)+2+4
@@ -832,19 +788,17 @@ class FmpRequestHandler(PatRequestHandler):
 
         self.sendNtcCircleBinary2(circle_index, partner, unk_data, seq)
 
-    def sendNtcCircleBinary2(self, circle_index, partner, unk_data,
-                             seq):
+    def sendNtcCircleBinary2(self, circle_index, partner, unk_data, seq):
         """NtcCircleBinary2 packet.
 
         ID: 65711000
         JP: サークルバイナリ送信 (相手指定)
         TR: Circle binary transmission (specified by the other party)
         """
-
         city = self.session.get_city()
         circle = city.circles[circle_index-1]
-        partner_session = next(
-            p for p in circle.players if p.capcom_id == partner)
+        partner_session = next(p for p in circle.players
+                               if p.capcom_id == partner)
         if partner_session is None:
             return
 
@@ -858,13 +812,11 @@ class FmpRequestHandler(PatRequestHandler):
         data += self_data.pack()
         data += unk_data
 
-        partner_pat_handler = self.server.get_pat_handler(
-            partner_session)
+        partner_pat_handler = self.server.get_pat_handler(partner_session)
         if partner_pat_handler is None:
             return
 
-        partner_pat_handler.send_packet(PatID4.NtcCircleBinary2, data,
-                                        seq)
+        partner_pat_handler.send_packet(PatID4.NtcCircleBinary2, data, seq)
 
     def recvReqCircleLeave(self, packet_id, data, seq):
         """ReqCircleLeave packet.
@@ -883,7 +835,6 @@ class FmpRequestHandler(PatRequestHandler):
         JP: サークルアウト返答
         TR: Circle out reply
         """
-
         data = struct.pack(">I", circle_index)
         self.send_packet(PatID4.AnsCircleLeave, data, seq)
 
@@ -894,27 +845,22 @@ class FmpRequestHandler(PatRequestHandler):
         JP: サークルデータ設定要求
         TR: Circle data setting request
         """
-
         circle_index, = struct.unpack_from(">I", data)
         offset = 4
         circle = pati.CircleInfo.unpack(data, offset)
         offset += len(circle.pack())
         optional_fields = pati.unpack_optional_fields(data, offset)
-        self.server.debug(
-            "ReqCircleInfoSet: Circle({}) {!r}, {!r}".format(
-                circle_index, circle, optional_fields))
-        self.sendAnsCircleInfoSet(circle_index, circle, optional_fields,
-                                  seq)
+        self.server.debug("ReqCircleInfoSet: Circle({}) {!r}, {!r}".format(
+                          circle_index, circle, optional_fields))
+        self.sendAnsCircleInfoSet(circle_index, circle, optional_fields, seq)
 
-    def sendAnsCircleInfoSet(self, circle_index, circle,
-                             optional_fields, seq):
+    def sendAnsCircleInfoSet(self, circle_index, circle, optional_fields, seq):
         """AnsCircleInfoSet packet.
 
         ID: 65200200
         JP: サークルデータ設定返答
         TR: Circle data setting reply
         """
-
         ntc_data = struct.pack(">I", circle_index)
         ntc_data += circle.pack()
         ntc_data += pati.pack_optional_fields(optional_fields)
@@ -951,7 +897,6 @@ class FmpRequestHandler(PatRequestHandler):
         JP: マッチング開始返答
         TR: Matching start reply
         """
-
         self.sendNtcCircleMatchStart(seq)
         self.send_packet(PatID4.AnsCircleMatchStart, b"", seq)
 
@@ -962,7 +907,6 @@ class FmpRequestHandler(PatRequestHandler):
         JP: マッチング開始通知
         TR: Matching start notification
         """
-
         circle = self.session.get_circle()
 
         count = circle.get_population()
@@ -979,8 +923,7 @@ class FmpRequestHandler(PatRequestHandler):
 
         for circle_player in circle.players:
             pat_handler = self.server.get_pat_handler(circle_player)
-            pat_handler.send_packet(PatID4.NtcCircleMatchStart, data,
-                                    seq)
+            pat_handler.send_packet(PatID4.NtcCircleMatchStart, data, seq)
 
     def recvReqCircleMatchEnd(self, packet_id, data, seq):
         """ReqCircleMatchEnd packet.
@@ -1002,6 +945,7 @@ class FmpRequestHandler(PatRequestHandler):
 
 
 BASE = server_base("FMP", FmpServer, FmpRequestHandler)
+
 
 if __name__ == "__main__":
     server_main(*BASE)

--- a/mh/constants.py
+++ b/mh/constants.py
@@ -23,7 +23,7 @@ import struct
 
 
 def pad(s, size, p=b'\0'):
-    data = bytearray(s+p * max(0, size-len(s)))
+    data = bytearray(s + p * max(0, size-len(s)))
     data[-1] = 0
     return data
 
@@ -57,7 +57,7 @@ def make_binary_server_type_list(is_jap=False):
             LINE_LENGTH = 24
             while b'\n' in desc:
                 i = desc.index(b'\n')
-                padding = (LINE_LENGTH-i % LINE_LENGTH) % LINE_LENGTH
+                padding = (LINE_LENGTH - i % LINE_LENGTH) % LINE_LENGTH
                 desc[i:i+1] = b' ' * padding
         data += pad(desc, 112 if is_jap else 168)
 
@@ -187,51 +187,52 @@ def make_binary_trading_post():
         return struct.pack(">HH", item, qty)
 
     # Popfish x8 <- Machalite Ore x2 | Rathian Coin x2
-    data += slot(0xd2, 8)+slot(0x65, 2)+slot(0x262, 2)+slot(0, 0)
+    data += slot(0xd2, 8) + slot(0x65, 2) + slot(0x262, 2) + slot(0, 0)
 
     # Waterblock Seed x3 <- Bone x4 | Qurupeco Coin x1
-    data += slot(0x188, 3)+slot(0xc4, 4)+slot(0x25f, 1)+slot(0, 0)
+    data += slot(0x188, 3) + slot(0xc4, 4) + slot(0x25f, 1) + slot(0, 0)
 
     # Bone Husk S x10 <- Bone x2 | Barroth Coin x2
-    data += slot(0x156, 10)+slot(0xc4, 2)+slot(0x260, 2)+slot(0, 0)
+    data += slot(0x156, 10) + slot(0xc4, 2) + slot(0x260, 2) + slot(0, 0)
 
     # Dung x5 <- Monster Fluid x1 | R.Ludroth Coin x1
-    data += slot(0xc5, 5)+slot(0x155, 1)+slot(0x261, 1)+slot(0, 0)
+    data += slot(0xc5, 5) + slot(0x155, 1) + slot(0x261, 1) + slot(0, 0)
 
     # Sharpened Fang x5 <- Hydro Hide x2 | R.Ludroth Coin x2
-    data += slot(0x232, 5)+slot(0x141, 1)+slot(0x261, 2)+slot(0, 0)
+    data += slot(0x232, 5) + slot(0x141, 1) + slot(0x261, 2) + slot(0, 0)
 
     # Toadstool x5 <- Sharpened Fang x1 | Qurupeco Coin x1
-    data += slot(0x158, 5)+slot(0x232, 1)+slot(0x25f, 1)+slot(0, 0)
+    data += slot(0x158, 5) + slot(0x232, 1) + slot(0x25f, 1) + slot(0, 0)
 
     # Stone x10 <- Monster Bone M x1 | Great Jaggi Coin x2
-    data += slot(0x61, 10)+slot(0x9a, 1)+slot(0x25e, 2)+slot(0, 0)
+    data += slot(0x61, 10) + slot(0x9a, 1) + slot(0x25e, 2) + slot(0, 0)
 
     # Spider Web x5 <- Monster Fluid x1 | Barroth Coin x1
-    data += slot(0xc6, 5)+slot(0x155, 1)+slot(0x260, 1)+slot(0, 0)
+    data += slot(0xc6, 5) + slot(0x155, 1) + slot(0x260, 1) + slot(0, 0)
 
     # Bughopper x10 <- Big Fin x3 | R.Ludroth Coin x2
-    data += slot(0x160, 10)+slot(0x230, 3)+slot(0x261, 2)+slot(0, 0)
+    data += slot(0x160, 10) + slot(0x230, 3) + slot(0x261, 2) + slot(0, 0)
 
     # Icethaw Pellet x3 <- Mystery Bone x4 | R.Ludroth Coin x1
-    data += slot(0x189, 3)+slot(0x10e, 4)+slot(0x261, 1)+slot(0, 0)
+    data += slot(0x189, 3) + slot(0x10e, 4) + slot(0x261, 1) + slot(0, 0)
 
     # Rathian Scale x1 <- Rathian Coin x3 | Pinnacle Coin x2
-    data += slot(0x112, 1)+slot(0x262, 3)+slot(0x267, 2)+slot(0, 0)
+    data += slot(0x112, 1) + slot(0x262, 3) + slot(0x267, 2) + slot(0, 0)
 
     # Wyvern Claw x8 <- Great Baggi Claw x1 | Rathian Coin x1
-    data += slot(0x167, 8)+slot(0x21d, 1)+slot(0x262, 1)+slot(0, 0)
+    data += slot(0x167, 8) + slot(0x21d, 1) + slot(0x262, 1) + slot(0, 0)
 
     # Prize Gold Sword x1 <- Lagiacrus Coin x15 | Pinnacle Coin x8
-    data += slot(0x25d, 1)+slot(0x263, 15)+slot(0x267, 8)+slot(0, 0)
+    data += slot(0x25d, 1) + slot(0x263, 15) + slot(0x267, 8) + slot(0, 0)
 
     # Barioth Shell x1 <- Barioth Coin x3 | Pinnacle Coin x2
-    data += slot(0x194, 1)+slot(0x24a, 3)+slot(0x267, 2)+slot(0, 0)
+    data += slot(0x194, 1) + slot(0x24a, 3) + slot(0x267, 2) + slot(0, 0)
 
     # Armor Stone x3 <- Deviljho Coin x1 | Pinnacle Coin x1
-    data += slot(0x1bb, 3)+slot(0x24d, 1)+slot(0x267, 1)+slot(0, 0)
+    data += slot(0x1bb, 3) + slot(0x24d, 1) + slot(0x267, 1) + slot(0, 0)
 
     return data
+
 
 LAYER_CHAT_COLORS = (0xbb3385ff, 0xffffffff, 0xffffffff)
 
@@ -276,8 +277,7 @@ PAT_BINARIES = {
     },
     0x05: {  # English
         "version": 1,
-        "content": b"5" * 0x10
-        # b"titi\ttoto\ttutu\nbibi\tbobo\bubu\nouba\t"
+        "content": b"5" * 0x10  # b"titi\ttoto\ttutu\nbibi\tbobo\bubu\nouba\t"
         # "version": 1,
         # "content": b"TEST_BINARY"
     },

--- a/mh/database.py
+++ b/mh/database.py
@@ -52,7 +52,6 @@ class Players(list):
     """
     TODO: Probably use a better container or another approach.
     """
-
     def add(self, item):
         if item not in self:
             self.append(item)
@@ -91,7 +90,7 @@ class City(object):
         self.players = Players()
         self.leader = None
         self.circles = [
-            Circle(self) for _ in range(self.capacity) # One circle per player
+            Circle(self) for _ in range(self.capacity)  # One circle per player
         ]
 
     def get_population(self):
@@ -113,20 +112,17 @@ class City(object):
         for index, circle in enumerate(self.circles):
             if circle.is_empty():
                 return circle, index
-
         return None, None
 
     def get_circle_for(self, leader_session):
         for index, circle in enumerate(self.circles):
             if circle.leader == leader_session:
                 return circle, index
-
         return None, None
 
 
 class Gate(object):
-    def __init__(self, name, parent, city_count=40,
-                 player_capacity=100):
+    def __init__(self, name, parent, city_count=40, player_capacity=100):
         self.name = name
         self.parent = parent
         self.state = LayerState.EMPTY
@@ -138,7 +134,7 @@ class Gate(object):
         self.players = Players()
 
     def get_population(self):
-        return len(self.players)+sum((
+        return len(self.players) + sum((
             city.get_population()
             for city in self.cities
         ))
@@ -171,7 +167,7 @@ class Server(object):
         self.players = Players()
 
     def get_population(self):
-        return len(self.players)+sum((
+        return len(self.players) + sum((
             gate.get_population() for gate in self.gates
         ))
 
@@ -322,7 +318,7 @@ class TempDatabase(object):
 
     def get_server(self, index):
         assert 0 < index <= len(self.servers), "Invalid server index"
-        return self.servers[index-1]
+        return self.servers[index - 1]
 
     def get_gates(self, server_id):
         return self.get_server(server_id).gates
@@ -330,7 +326,7 @@ class TempDatabase(object):
     def get_gate(self, server_id, index):
         gates = self.get_gates(server_id)
         assert 0 < index <= len(gates), "Invalid gate index"
-        return gates[index-1]
+        return gates[index - 1]
 
     def join_gate(self, session, server_id, index):
         gate = self.get_gate(server_id, index)
@@ -354,7 +350,7 @@ class TempDatabase(object):
     def get_city(self, server_id, gate_id, index):
         cities = self.get_cities(server_id, gate_id)
         assert 0 < index <= len(cities), "Invalid city index"
-        return cities[index-1]
+        return cities[index - 1]
 
     def join_city(self, session, server_id, gate_id, index):
         city = self.get_city(server_id, gate_id, index)

--- a/mh/pat.py
+++ b/mh/pat.py
@@ -19,13 +19,14 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import mh.pat_item as pati
-import mh.time_utils as time_utils
 import select
 import struct
 import time
 import traceback
 from datetime import datetime, timedelta
+
+import mh.pat_item as pati
+import mh.time_utils as time_utils
 from mh.constants import *
 from mh.session import Session
 from other.utils import Logger, get_config, get_ip, hexdump
@@ -235,8 +236,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
 
         The game requests the terms version and its total size.
         """
-        self.sendAnsTermsVersion(TERMS_VERSION,
-                                 len(TERMS[TERMS_VERSION]), seq)
+        self.sendAnsTermsVersion(TERMS_VERSION, len(TERMS[TERMS_VERSION]), seq)
 
     def sendAnsTermsVersion(self, terms_version, terms_size, seq):
         """AnsTermsVersion packet.
@@ -492,8 +492,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         TODO: I don't think it's related to LMP protocol.
         """
         config = get_config("LMP")
-        self.sendAnsLmpConnect(get_ip(config["IP"]), config["Port"],
-                               seq)
+        self.sendAnsLmpConnect(get_ip(config["IP"]), config["Port"], seq)
 
     def sendAnsLmpConnect(self, address, port, seq):
         """AnsLmpConnect packet.
@@ -554,8 +553,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
             int(timedelta(days=1).total_seconds())
         )
         info.unk_binary_0x05 = pati.Binary("Cid")
-        info.online_support_code = pati.String(
-            self.session.get_support_code())
+        info.online_support_code = pati.String(self.session.get_support_code())
         data = info.pack()
         self.send_packet(PatID4.AnsChargeInfo, data, seq)
 
@@ -614,7 +612,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         TR: PAT ticket response
         """
         pat_ticket = self.session.new_pat_ticket()
-        data = struct.pack(">H", len(pat_ticket))+pat_ticket
+        data = struct.pack(">H", len(pat_ticket)) + pat_ticket
         self.send_packet(PatID4.AnsTicket, data, seq)
 
     def recvReqUserListHead(self, packet_id, data, seq):
@@ -731,8 +729,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         user_obj.capcom_id = pati.String(self.session.capcom_id)
         self.sendAnsUserObject(is_slot_empty, slot_index, user_obj, seq)
 
-    def sendAnsUserObject(self, is_slot_empty, slot_index, user_obj,
-                          seq):
+    def sendAnsUserObject(self, is_slot_empty, slot_index, user_obj, seq):
         """AnsUserObject packet.
 
         ID: 61200200
@@ -991,8 +988,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
          - Spanish: 0x41, 0x3d, 0x41, 0x3e, 0x3f, 0x40
         """
         binary = PAT_BINARIES[binary_type]
-        data = struct.pack(">II", binary["version"],
-                           len(binary["content"]))
+        data = struct.pack(">II", binary["version"], len(binary["content"]))
         self.send_packet(PatID4.AnsBinaryHead, data, seq)
 
     def recvReqBinaryData(self, packet_id, data, seq):
@@ -1004,11 +1000,9 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
 
         TODO: Handle multiple versions of a binary
         """
-        binary_type, version, offset, size = struct.unpack(">BIII",
-                                                           data)
+        binary_type, version, offset, size = struct.unpack(">BIII", data)
         binary = PAT_BINARIES[binary_type]
-        self.sendAnsBinaryData(version, offset, size, binary["content"],
-                               seq)
+        self.sendAnsBinaryData(version, offset, size, binary["content"], seq)
 
     def sendAnsBinaryData(self, version, offset, size, binary, seq):
         """AnsBinaryData packet.
@@ -1048,10 +1042,9 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         TR: User search data request
         """
         name = pati.unpack_lp2_string(data)
-        offset = 2+len(name)
+        offset = 2 + len(name)
         search_info = pati.UserSearchInfo.unpack(data, offset)
-        self.server.debug(
-            "SearchInfo: {}, {!r}".format(name, search_info))
+        self.server.debug("SearchInfo: {}, {!r}".format(name, search_info))
         self.sendAnsUserSearchInfo(name, search_info, seq)
 
     def sendAnsUserSearchInfo(self, name, search_info, seq):
@@ -1068,7 +1061,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         # Warp location ?
         user.unk_binary_0x04 = pati.Binary(
             # Long: ? + server_type? / Word: server? + gate? + city?
-            b"\0\0\0\01"+b"\0\0\0\01"+b"\0\01"+b"\0\01"+b"\0\01"
+            b"\0\0\0\01" + b"\0\0\0\01" + b"\0\01" + b"\0\01" + b"\0\01"
         )
         user.unk_byte_0x07 = pati.Byte(1)
         user.server_name = pati.String("Server\tGate\tCity")
@@ -1077,13 +1070,14 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         user.city_size = pati.Long(4)
         user.city_capacity = pati.Long(3)
 
-        # This fields are used to identify a user. Specifically when a client is deserializing data from the packets
+        # This fields are used to identify a user.
+        # Specifically when a client is deserializing data from the packets
         # `NtcLayerBinary` and `NtcLayerBinary2`
         # TODO: Proper field value and name
-        user.info_mine_0x0f = pati.Long(
-            int(hash(OTHER_CAPCOM_ID)) & 0xffffffff)
-        user.info_mine_0x10 = pati.Long(
-            int(hash(OTHER_CAPCOM_ID[::-1])) & 0xffffffff)
+        user.info_mine_0x0f = pati.Long(int(hash(OTHER_CAPCOM_ID))
+                                        & 0xffffffff)
+        user.info_mine_0x10 = pati.Long(int(hash(OTHER_CAPCOM_ID[::-1]))
+                                        & 0xffffffff)
 
         data = user.pack()
         # TODO: Figure out the optional fields
@@ -1098,7 +1092,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         TR: Layer start request
         """
         unk1 = pati.unpack_bytes(data)
-        unk2 = pati.unpack_bytes(data, len(unk1)+1)
+        unk2 = pati.unpack_bytes(data, len(unk1) + 1)
         self.sendAnsLayerStart(unk1, unk2, seq)
 
     def sendAnsLayerStart(self, unk1, unk2, seq):
@@ -1119,7 +1113,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         TR: Circle notification subscription request
         """
         unk1 = pati.unpack_bytes(data)
-        unk2 = pati.unpack_bytes(data, len(unk1)+1)
+        unk2 = pati.unpack_bytes(data, len(unk1) + 1)
         self.sendAnsCircleInfoNoticeSet(unk1, unk2, seq)
 
     def sendAnsCircleInfoNoticeSet(self, unk1, unk2, seq):
@@ -1193,15 +1187,13 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         """
         unk, = struct.unpack_from(">B", data)
         layer = pati.unpack_lp2_string(data, 1)
-        offset = 1+len(layer)+2
+        offset = 1 + len(layer) + 2
         first_index, count = struct.unpack_from(">II", data, offset)
         offset += 8
         fields = pati.unpack_bytes(data, offset)
-        self.server.debug(
-            "LayerUserListHead({}, {!r}, {}, {}, {!r}".format(
-                unk, layer, first_index, count, fields))
-        self.sendAnsLayerUserListHead(unk, layer, first_index, count,
-                                      fields,
+        self.server.debug("LayerUserListHead({}, {!r}, {}, {}, {!r}".format(
+                          unk, layer, first_index, count, fields))
+        self.sendAnsLayerUserListHead(unk, layer, first_index, count, fields,
                                       seq)
 
     def sendAnsLayerUserListHead(self, unk, layer, first_index, count,
@@ -1215,8 +1207,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         """
         depth, server_id, unk_id, gate_id, city_id = struct.unpack_from(
             ">IIHHH", layer)
-        search_payload = (
-            server_id, gate_id, city_id, first_index, count)
+        search_payload = (server_id, gate_id, city_id, first_index, count)
         users = self.session.get_layer_users(*search_payload)
         self.session.search_payload = search_payload
         data = struct.pack(">II", first_index, len(users))
@@ -1240,7 +1231,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         TR: Layer user list response
         """
         unk = 1
-        search_payload = self.session.search_payload[:-2]+(
+        search_payload = self.session.search_payload[:-2] + (
             first_index, count)
         users = self.session.get_layer_users(*search_payload)
         self.session.search_payload = None
@@ -1252,9 +1243,9 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
             layer_user.layer_host = pati.Binary(
                 b'\x00\x00\x00\x03'  # Depth?
                 b'\x00\x00\x00\x01'  # Unknown
-                b'\x00\x01'  # Server ID?
-                b'\x00\x01'  # Gate ID?
-                b'\x00\x01'  # City ID?
+                b'\x00\x01'          # Server ID?
+                b'\x00\x01'          # Gate ID?
+                b'\x00\x01'          # City ID?
             )
             data += layer_user.pack()
             # User summary?
@@ -1264,12 +1255,12 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
             # Index 4/4 - ??? (u32)
             count = 4
             data += pati.pack_optional_fields([
-                                                  (i, 0x03030303)
-                                                  for i in range(3, 5)
-                                              ]+[
-                                                  (1, 0x03000001),
-                                                  (2, 0x00ff0000)
-                                              ])
+                (i, 0x03030303)
+                for i in range(3, 5)
+            ] + [
+                (1, 0x03000001),
+                (2, 0x00ff0000)
+            ])
         self.send_packet(PatID4.AnsLayerUserListData, data, seq)
 
     def recvReqLayerUserListFoot(self, packet_id, data, seq):
@@ -1331,7 +1322,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         TR: Black data registration request
         """
         capcom_id = pati.unpack_lp2_string(data)
-        offset = len(capcom_id)+2
+        offset = len(capcom_id) + 2
         black_data = pati.BlackListUserData.unpack(data, offset)
         self.sendAnsBlackAdd(capcom_id, black_data, seq)
 
@@ -1405,7 +1396,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         """
         unk1, = struct.unpack_from(">B", data)
         info = pati.MessageInfo.unpack(data, 1)
-        offset = 1+len(info.pack())
+        offset = 1 + len(info.pack())
         message = pati.unpack_lp2_string(data, offset)
         self.server.debug("NtcLayerChat: {}, {!r}, {}".format(
             unk1, info, message))
@@ -1441,7 +1432,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         TR: Send partner message
         """
         recipient_id = pati.unpack_lp2_string(data)
-        offset = 2+len(recipient_id)
+        offset = 2 + len(recipient_id)
         info = pati.MessageInfo.unpack(data, offset)
         offset += len(info.pack())
         message = pati.unpack_lp2_string(data, offset)
@@ -1483,7 +1474,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         TODO: Merge this with ReqTell?
         """
         recipient_id = pati.unpack_lp2_string(data)
-        offset = 2+len(recipient_id)
+        offset = 2 + len(recipient_id)
         info = pati.MessageInfo.unpack(data, offset)
         offset += len(info.pack())
         message = pati.unpack_lp2_string(data, offset)
@@ -1619,8 +1610,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         """
         unk = first_index
         data = struct.pack(">II", unk, count)
-        data += pati.get_layer_children(self.session, first_index,
-                                        count)
+        data += pati.get_layer_children(self.session, first_index, count)
         self.send_packet(PatID4.AnsLayerChildListData, data, seq)
 
     def recvReqLayerChildListFoot(self, packet_id, data, seq):
@@ -1723,8 +1713,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         TR: Child layer information request
         """
         unk1, = struct.unpack_from(">H", data)
-        layer_data = data[
-                     2:]  # layer_data with some unknown ones appended
+        layer_data = data[2:]  # layer_data with some unknown ones appended
         self.sendAnsLayerChildInfo(unk1, layer_data, seq)
 
     def sendAnsLayerChildInfo(self, unk1, layer_data, seq):
@@ -2081,8 +2070,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         name = "recv{}".format(PAT_NAMES[packet_id])
 
         if not hasattr(self, name):
-            self.server.error("Unsupported packet: %08x | %s",
-                              packet_id, name)
+            self.server.error("Unsupported packet: %08x | %s", packet_id, name)
             return
 
         handler = getattr(self, name)
@@ -2090,10 +2078,9 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
 
     def handle_client(self):
         """Select handler."""
-        timeout = time.time()+30
+        timeout = time.time() + 30
         while True:
-            r, w, e = select.select([self.rfile], [self.wfile], [],
-                                    0.2123)
+            r, w, e = select.select([self.rfile], [self.wfile], [], 0.2123)
             if r:
                 header = self.rfile.read(8)
                 if not len(header):
@@ -2109,7 +2096,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
                 current_time = time.time()
                 if current_time > timeout:
                     self.sendReqLineCheck()
-                    timeout = current_time+30
+                    timeout = current_time + 30
             if e:
                 self.server.error("Select error: %s", e)
 

--- a/mh/pat_item.py
+++ b/mh/pat_item.py
@@ -39,7 +39,7 @@ class ItemType:
 def lp_string(s):
     """1-byte length-prefixed string."""
     s = to_bytearray(s)
-    return struct.pack(">B", len(s))+s
+    return struct.pack(">B", len(s)) + s
 
 
 def unpack_lp_string(data, offset=0):
@@ -51,7 +51,7 @@ def unpack_lp_string(data, offset=0):
 def lp2_string(s):
     """2-bytes length-prefixed string."""
     s = to_bytearray(s)
-    return struct.pack(">H", len(s))+s
+    return struct.pack(">H", len(s)) + s
 
 
 def unpack_lp2_string(data, offset=0):
@@ -133,7 +133,6 @@ def unpack_optional_fields(data, offset=0):
 
 class Byte(Item):
     """PAT item byte class."""
-
     def __new__(cls, b):
         return Item.__new__(cls, pack_byte(b))
 
@@ -163,7 +162,6 @@ def unpack_word(data, offset=0):
 
 class Word(Item):
     """PAT item word class."""
-
     def __new__(cls, w):
         return Item.__new__(cls, pack_word(w))
 
@@ -193,7 +191,6 @@ def unpack_long(data, offset=0):
 
 class Long(Item):
     """PAT item long class."""
-
     def __new__(cls, lg):
         return Item.__new__(cls, pack_long(lg))
 
@@ -210,16 +207,14 @@ def unpack_longlong(data, offset=0):
     """Unpack PAT item long long."""
     item_type, value = struct.unpack_from(">BQ", data, offset)
     if item_type != ItemType.LongLong:
-        raise AssertionError(
-            "Invalid type for long long item: {}".format(
-                item_type
-            ))
+        raise AssertionError("Invalid type for long long item: {}".format(
+            item_type
+         ))
     return value
 
 
 class LongLong(Item):
     """PAT item long long class."""
-
     def __new__(cls, q):
         return Item.__new__(cls, pack_longlong(q))
 
@@ -229,7 +224,7 @@ class LongLong(Item):
 
 def pack_string(s):
     """Pack PAT item string."""
-    return struct.pack(">B", ItemType.String)+lp2_string(s)
+    return struct.pack(">B", ItemType.String) + lp2_string(s)
 
 
 def unpack_string(data, offset=0):
@@ -244,7 +239,6 @@ def unpack_string(data, offset=0):
 
 class String(Item):
     """PAT item string class."""
-
     def __new__(cls, s):
         return Item.__new__(cls, pack_string(s))
 
@@ -255,7 +249,7 @@ class String(Item):
 def pack_binary(s):
     """Pack PAT item binary."""
     s = to_bytearray(s)
-    return struct.pack(">BH", ItemType.Binary, len(s))+s
+    return struct.pack(">BH", ItemType.Binary, len(s)) + s
 
 
 def unpack_binary(data, offset=0):
@@ -270,7 +264,6 @@ def unpack_binary(data, offset=0):
 
 class Binary(Item):
     """PAT item binary class."""
-
     def __new__(cls, b):
         return Item.__new__(cls, pack_binary(b))
 
@@ -294,9 +287,8 @@ def unpack_any(data, offset=0):
 
 class Custom(Item):
     """PAT custom item class."""
-
     def __new__(cls, b, item_type=b'\0'):
-        return Item.__new__(cls, item_type+b)
+        return Item.__new__(cls, item_type + b)
 
     def __repr__(self):
         return "Custom({!r})".format(repr(self[1:]))
@@ -311,7 +303,6 @@ class FallthroughBug(Custom):
 
     The workaround uses a dummy field_0xff which will be clobbered on purpose.
     """
-
     def __new__(cls):
         return Custom.__new__(cls, b"\xff", b"\xff")
 
@@ -319,7 +310,7 @@ class FallthroughBug(Custom):
 def unpack_bytes(data, offset=0):
     """Unpack bytes list."""
     count, = struct.unpack_from(">B", data, offset)
-    return struct.unpack_from(">"+count * "B", data, offset+1)
+    return struct.unpack_from(">" + count * "B", data, offset+1)
 
 
 class PatData(OrderedDict):
@@ -360,14 +351,12 @@ class PatData(OrderedDict):
         for field_id, field_name in self.FIELDS:
             if name == field_name:
                 if not isinstance(value, Item):
-                    raise ValueError(
-                        "{!r} not a valid PAT item".format(value))
+                    raise ValueError("{!r} not a valid PAT item".format(value))
                 self[field_id] = value
                 return
         if name.startswith("_"):
             return OrderedDict.__setattr__(self, name, value)
-        raise AttributeError(
-            "Cannot set unknown field: {}".format(name))
+        raise AttributeError("Cannot set unknown field: {}".format(name))
 
     def __delattr__(self, name):
         for field_id, field_name in self.FIELDS:
@@ -396,8 +385,8 @@ class PatData(OrderedDict):
             for index, value in self.items()
             if value is not None
         ]
-        return struct.pack(">B", len(items))+b"".join(
-            (struct.pack(">B", index)+value)
+        return struct.pack(">B", len(items)) + b"".join(
+            (struct.pack(">B", index) + value)
             for index, value in items
         )
 
@@ -408,8 +397,8 @@ class PatData(OrderedDict):
             for index, value in self.items()
             if value is not None and index in fields
         ]
-        return struct.pack(">B", len(items))+b"".join(
-            (struct.pack(">B", index)+value)
+        return struct.pack(">B", len(items)) + b"".join(
+            (struct.pack(">B", index) + value)
             for index, value in items
         )
 
@@ -437,10 +426,10 @@ class PatData(OrderedDict):
                 offset += 8
             elif item_type == ItemType.String:
                 obj[field_id] = String(value)
-                offset += 2+len(value)
+                offset += 2 + len(value)
             elif item_type == ItemType.Binary:
                 obj[field_id] = Binary(value)
-                offset += 2+len(value)
+                offset += 2 + len(value)
             else:
                 raise ValueError("Unknown type: {}".format(item_type))
         return obj
@@ -448,8 +437,7 @@ class PatData(OrderedDict):
     def assert_fields(self, fields):
         items = set(self.keys())
         fields = set(fields)
-        message = "Fields mismatch: {}\n -> Expected: {}".format(items,
-                                                                 fields)
+        message = "Fields mismatch: {}\n -> Expected: {}".format(items, fields)
         assert items == fields, message
 
 
@@ -677,16 +665,17 @@ class LayerBinaryInfo(PatData):
 
 class HunterSettings(object):
     SIZE = 0x100
-    
+
     def __init__(self):
         self.data = bytearray(self.SIZE)
-    
+
     def unpack(self, data, length, offset=0):
         self.data[offset:offset+length] = data
         return self
 
     def pack(self):
         return self.data
+
 
 def get_fmp_servers(session, first_index, count):
     assert first_index > 0, "Invalid list index"
@@ -696,8 +685,8 @@ def get_fmp_servers(session, first_index, count):
     fmp_port = config["Port"]
 
     data = b""
-    start = first_index-1
-    end = start+count
+    start = first_index - 1
+    end = start + count
     servers = session.get_servers()[start:end]
     for i, server in enumerate(servers, first_index):
         fmp_data = FmpData()
@@ -723,7 +712,7 @@ def get_layer_children(session, first_index, count, sibling=False):
     assert first_index > 0, "Invalid list index"
 
     data = b""
-    start = first_index-1
+    start = first_index - 1
     end = start+count
     if not sibling:
         children = session.get_layer_children()[start:end]

--- a/mh/session.py
+++ b/mh/session.py
@@ -33,7 +33,6 @@ class Session(object):
     TODO:
      - Finish the implementation
     """
-
     def __init__(self):
         """Create a session object."""
         self.local_info = {
@@ -156,7 +155,7 @@ class Session(object):
 
     def get_layer_users(self, server_id, gate_id, city_id, first_index, count):
         players = list(DB.get_city(server_id, gate_id, city_id).players)
-        start = first_index-1
+        start = first_index - 1
         return players[start:start+count]
 
     def leave_server(self):


### PR DESCRIPTION
This PR reverts some weird formatting changes like confusing newline, space removal between operators, etc. A rule of thumb would be not to lint code unrelated to a PR and avoid auto-linting the code. Using `pep8` and `pycodestyle` from time to time is more than enough. Unless the code is really dirty, it's rare to trigger the linter.

Ready to be reviewed & merged when tested.