### PR TITLE
PAT: Use layer's optional fields

### DIFF
--- a/mh/database.py
+++ b/mh/database.py
@@ -88,6 +88,7 @@ class City(object):
         self.capacity = 4
         self.state = LayerState.EMPTY
         self.players = Players()
+        self.optional_fields = []
         self.leader = None
         self.circles = [
             Circle(self) for _ in range(self.capacity)  # One circle per player
@@ -132,6 +133,7 @@ class Gate(object):
             for i in range(1, city_count+1)
         ]
         self.players = Players()
+        self.optional_fields = []
 
     def get_population(self):
         return len(self.players) + sum((
@@ -351,6 +353,12 @@ class TempDatabase(object):
         cities = self.get_cities(server_id, gate_id)
         assert 0 < index <= len(cities), "Invalid city index"
         return cities[index - 1]
+
+    def create_city(self, session, server_id, gate_id, index,
+                    settings, optional_fields):
+        city = self.get_city(server_id, gate_id, index)
+        city.optional_fields = optional_fields
+        return city
 
     def join_city(self, session, server_id, gate_id, index):
         city = self.get_city(server_id, gate_id, index)

--- a/mh/pat.py
+++ b/mh/pat.py
@@ -1923,12 +1923,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         TR: Layer creation settings response
         """
         data = struct.pack(">H", number)
-        self.session.layer_down(number)
-
-        if self.session.layer == 2:
-            city = self.session.get_city()
-            city.leader = self.session
-
+        self.session.layer_create(number, layer_set, extra)
         self.send_packet(PatID4.AnsLayerCreateSet, data, seq)
 
     def recvReqLayerCreateFoot(self, packet_id, data, seq):

--- a/mh/pat_item.py
+++ b/mh/pat_item.py
@@ -730,8 +730,7 @@ def get_layer_children(session, first_index, count, sibling=False):
         # layer.fallthrough_bug = FallthroughBug()
         layer.unk_byte_0x12 = Byte(1)
         data += layer.pack()
-        # A strange struct is also used, try to skip it
-        data += struct.pack(">B", 0)
+        data += pack_optional_fields(child.optional_fields)
     return data
 
 

--- a/mh/session.py
+++ b/mh/session.py
@@ -127,6 +127,14 @@ class Session(object):
             assert False, "Can't go down a layer"
         self.layer += 1
 
+    def layer_create(self, layer_id, settings, optional_fields):
+        if self.layer == 1:
+            city = self.create_city(layer_id, settings, optional_fields)
+            city.leader = self
+        else:
+            assert False, "Can't create a layer from L{}".format(self.layer)
+        self.layer_down(layer_id)
+
     def layer_up(self):
         if self.layer == 1:
             self.leave_gate()
@@ -173,6 +181,12 @@ class Session(object):
     def get_cities(self):
         return DB.get_cities(self.local_info["server_id"],
                              self.local_info["gate_id"])
+
+    def create_city(self, city_id, settings, optional_fields):
+        return DB.create_city(self,
+                              self.local_info["server_id"],
+                              self.local_info["gate_id"],
+                              city_id, settings, optional_fields)
 
     def join_city(self, city_id):
         DB.join_city(self,


### PR DESCRIPTION
This PR retains city's optional fields used to display the city properties at the gate.

I'll test it soon to make sure it doesn't break anything, meanwhile I'm setting it as a draft.