### PR TITLE
Fix CapcomID persistence across session

### DIFF
--- a/mh/database.py
+++ b/mh/database.py
@@ -273,10 +273,10 @@ class TempDatabase(object):
         session.capcom_id = capcom_id
         session.hunter_name = name
 
-    def get_session(self, session):
-        """Returns existing PAT session or the current one."""
-        session = self.sessions.get(session.pat_ticket, session)
-        if session.capcom_id:
+    def get_session(self, pat_ticket):
+        """Returns existing PAT session or None."""
+        session = self.sessions.get(pat_ticket)
+        if session and session.capcom_id:
             self.use_capcom_id(session, session.capcom_id, session.hunter_name)
         return session
 

--- a/mh/database.py
+++ b/mh/database.py
@@ -247,8 +247,18 @@ class TempDatabase(object):
         self.sessions[session.pat_ticket] = session
         return session.pat_ticket
 
+    def use_capcom_id(self, session, capcom_id, name=None):
+        """Attach the session to the Capcom ID."""
+        assert capcom_id in self.capcom_ids, "Capcom ID doesn't exist"
+
+        not_in_use = self.capcom_ids[capcom_id]["session"] is None
+        assert not_in_use, "Capcom ID is already in use"
+
+        name = name or self.capcom_ids[capcom_id]["name"]
+        self.capcom_ids[capcom_id] = {"name": name, "session": session}
+
     def use_user(self, session, index, name):
-        """Use Capcom ID from the slot or create one if empty"""
+        """Use User from the slot or create one if empty"""
         assert 1 <= index <= 6, "Invalid Capcom ID slot"
         index -= 1
         users = self.consoles[session.online_support_code]
@@ -259,28 +269,30 @@ class TempDatabase(object):
                 break
         else:
             capcom_id = users[index]
-            not_in_use = self.capcom_ids[capcom_id]["session"] is None
-            assert not_in_use, "Capcom ID is already in use"
-        name = name or self.capcom_ids[capcom_id]["name"]
-        self.capcom_ids[capcom_id] = {"name": name, "session": session}
+        self.use_capcom_id(session, capcom_id, name)
         session.capcom_id = capcom_id
         session.hunter_name = name
 
     def get_session(self, session):
         """Returns existing PAT session or the current one."""
-        return self.sessions.get(session.pat_ticket, session)
+        session = self.sessions.get(session.pat_ticket, session)
+        if session.capcom_id:
+            self.use_capcom_id(session, session.capcom_id, session.hunter_name)
+        return session
 
-    def del_session(self, session):
+    def disconnect_session(self, session):
+        """Detach the session from its Capcom ID."""
+        if not session.capcom_id:
+            # Capcom ID isn't chosen yet with OPN/LMP servers
+            return
+        self.capcom_ids[session.capcom_id]["session"] = None
+
+    def delete_session(self, session):
         """Delete the session from the database."""
-        # TODO: Find a good place to purge old tickets
-        """
+        self.disconnect_session(session)
         pat_ticket = session.pat_ticket
         if pat_ticket in self.sessions:
             del self.sessions[pat_ticket]
-        """
-        capcom_id = session.capcom_id
-        if capcom_id in self.capcom_ids:
-            self.capcom_ids[capcom_id]["session"] = None
 
     def get_users(self, session, first_index, count):
         """Returns Capcom IDs tied to the session."""

--- a/mh/pat.py
+++ b/mh/pat.py
@@ -2108,7 +2108,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         """Default PAT handler."""
         self.server.info("Handle client")
         self.server.add_to_debug(self)
-        self.session = Session()
+        self.session = Session(self)
 
         # There are connect errors if too fast
         # TODO: investigate if it's Dolphin's fault
@@ -2116,9 +2116,10 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         self.sendReqConnection()
         try:
             self.handle_client()
+            self.session.disconnect()
         except Exception as e:
             traceback.print_exc()
+            self.session.delete()
 
-        self.session.delete()
         self.server.del_from_debug(self)
         self.server.info("Client finished!")

--- a/mh/session.py
+++ b/mh/session.py
@@ -65,7 +65,7 @@ class Session(object):
             self.online_support_code = to_str(
                 pati.unpack_string(connection_data.online_support_code)
             )
-        session = DB.get_session(self)
+        session = DB.get_session(self.pat_ticket) or self
         if session != self:
             assert session.connection is None, "Session is already in use"
             session.connection = self.connection

--- a/mh/session.py
+++ b/mh/session.py
@@ -33,7 +33,7 @@ class Session(object):
     TODO:
      - Finish the implementation
     """
-    def __init__(self):
+    def __init__(self, connection_handler):
         """Create a session object."""
         self.local_info = {
             "server_id": None,
@@ -44,7 +44,7 @@ class Session(object):
             "city_name": None,
             "circle_id": None,
         }
-        self.connection = None
+        self.connection = connection_handler
         self.online_support_code = None
         self.pat_ticket = None
         self.capcom_id = ""
@@ -65,15 +65,33 @@ class Session(object):
             self.online_support_code = to_str(
                 pati.unpack_string(connection_data.online_support_code)
             )
-        return DB.get_session(self)
+        session = DB.get_session(self)
+        if session != self:
+            assert session.connection is None, "Session is already in use"
+            session.connection = self.connection
+            self.connection = None
+        return session
 
     def get_support_code(self):
         """Return the online support code."""
         return DB.get_support_code(self)
 
+    def disconnect(self):
+        """Disconnect the current session.
+
+        It doesn't purge the session state nor its PAT ticket.
+        """
+        self.connection = None
+        DB.disconnect_session(self)
+
     def delete(self):
-        """Delete the current session from the database."""
-        DB.del_session(self)
+        """Delete the current session.
+
+        TODO:
+         - Find a good place to purge old tickets.
+         - We should probably create a SessionManager thread per server.
+        """
+        DB.delete_session(self)
 
     def is_jap(self):
         """TODO: Heuristic using the connection data to detect region."""


### PR DESCRIPTION
This PR prevents multiple users to use simultaneously the same Capcom ID. It also provides a wrapper that can forward tiny error messages to the game.

Ready to be reviewed & tested. 