### PR TITLE
PAT: Implement player search packets

### DIFF
--- a/mh/database.py
+++ b/mh/database.py
@@ -366,6 +366,23 @@ class TempDatabase(object):
         assert 0 < index <= len(cities), "Invalid city index"
         return cities[index - 1]
 
+    def get_all_users(self, server_id, gate_id, city_id):
+        """Search for users in layers and its children.
+
+        Let's assume wildcard search isn't possible for servers and gates.
+        A wildcard search happens when the id is zero.
+        """
+        assert 0 < server_id, "Invalid server index"
+        assert 0 < gate_id, "Invalid gate index"
+        gate = self.get_gate(server_id, gate_id)
+        users = list(gate.players)
+        cities = [
+            self.get_city(server_id, gate_id, city_id)
+        ] if city_id else self.get_cities(server_id, gate_id)
+        for city in cities:
+            users.extend(list(city.players))
+        return users
+
     def create_city(self, session, server_id, gate_id, index,
                     settings, optional_fields):
         city = self.get_city(server_id, gate_id, index)

--- a/mh/database.py
+++ b/mh/database.py
@@ -383,6 +383,21 @@ class TempDatabase(object):
             users.extend(list(city.players))
         return users
 
+    def find_users(self, capcom_id="", hunter_name=""):
+        assert capcom_id or hunter_name, "Search can't be empty"
+        users = []
+        for user_id, user_info in self.capcom_ids.items():
+            session = user_info["session"]
+            if not session:
+                continue
+            if capcom_id and capcom_id not in user_id:
+                continue
+            if hunter_name and \
+                    hunter_name.lower() not in user_info["name"].lower():
+                continue
+            users.append(session)
+        return users
+
     def create_city(self, session, server_id, gate_id, index,
                     settings, optional_fields):
         city = self.get_city(server_id, gate_id, index)

--- a/mh/database.py
+++ b/mh/database.py
@@ -316,10 +316,13 @@ class TempDatabase(object):
         server = self.get_server(index)
         server.players.add(session)
         session.local_info["server_id"] = index
+        session.local_info["server_name"] = server.name
         return server
 
     def leave_server(self, session, index):
         self.get_server(index).players.remove(session)
+        session.local_info["server_id"] = None
+        session.local_info["server_name"] = None
 
     def get_server_time(self):
         pass

--- a/mh/pat.py
+++ b/mh/pat.py
@@ -1305,27 +1305,9 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
             layer_user = pati.LayerUserInfo()
             layer_user.capcom_id = pati.String(user.capcom_id)
             layer_user.hunter_name = pati.String(user.hunter_name)
-            layer_user.layer_host = pati.Binary(
-                b'\x00\x00\x00\x03'  # Depth?
-                b'\x00\x00\x00\x01'  # Unknown
-                b'\x00\x01'          # Server ID?
-                b'\x00\x01'          # Gate ID?
-                b'\x00\x01'          # City ID?
-            )
+            layer_user.layer_host = pati.Binary(user.get_layer_host_data())
             data += layer_user.pack()
-            # User summary?
-            # Index 1/4 - Weapon (u8) + 16-bit padding + Location (u8)
-            # Index 2/4 - HR (u16) + 16-bit padding
-            # Index 3/4 - ??? (u8[4])
-            # Index 4/4 - ??? (u32)
-            count = 4
-            data += pati.pack_optional_fields([
-                (i, 0x03030303)
-                for i in range(3, 5)
-            ] + [
-                (1, 0x03000001),
-                (2, 0x00ff0000)
-            ])
+            data += pati.pack_optional_fields(user.get_optional_fields())
         self.send_packet(PatID4.AnsLayerUserListData, data, seq)
 
     def recvReqLayerUserListFoot(self, packet_id, data, seq):

--- a/mh/pat.py
+++ b/mh/pat.py
@@ -1231,8 +1231,8 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         ]))
         user_info.unk_byte_0x0b = pati.Byte(1)
         user_info.unk_string_0x0c = pati.String("StrC")
-        user_info.city_size = pati.Long(4)
-        user_info.city_capacity = pati.Long(3)
+        user_info.city_capacity = pati.Long(4)
+        user_info.city_size = pati.Long(3)
 
         # This fields are used to identify a user.
         # Specifically when a client is deserializing data from the packets

--- a/mh/pat.py
+++ b/mh/pat.py
@@ -1272,10 +1272,9 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         """
         depth, server_id, unk_id, gate_id, city_id = struct.unpack_from(
             ">IIHHH", layer)
-        search_payload = (server_id, gate_id, city_id, first_index, count)
-        users = self.session.get_layer_users(*search_payload)
-        self.session.search_payload = search_payload
-        data = struct.pack(">II", first_index, len(users))
+        self.search_data = self.session.find_users_by_layer(
+            server_id, gate_id, city_id, first_index, count)
+        data = struct.pack(">II", first_index, len(self.search_data))
         self.send_packet(PatID4.AnsLayerUserListHead, data, seq)
 
     def recvReqLayerUserListData(self, packet_id, data, seq):
@@ -1296,10 +1295,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         TR: Layer user list response
         """
         unk = 1
-        search_payload = self.session.search_payload[:-2] + (
-            first_index, count)
-        users = self.session.get_layer_users(*search_payload)
-        self.session.search_payload = None
+        users = self.search_data
         data = struct.pack(">II", unk, len(users))
         for user in users:
             layer_user = pati.LayerUserInfo()

--- a/mh/pat_item.py
+++ b/mh/pat_item.py
@@ -572,9 +572,9 @@ class FmpData(PatData):
 class UserSearchInfo(PatData):
     FIELDS = (
         (0x01, "capcom_id"),
-        (0x02, "name"),
-        (0x03, "unk_binary_0x03"),  # Hunter stat/HR related
-        (0x04, "unk_binary_0x04"),  # Warp related
+        (0x02, "hunter_name"),
+        (0x03, "stats"),
+        (0x04, "layer_host"),
         (0x07, "unk_byte_0x07"),
         (0x08, "server_name"),
         (0x0b, "unk_byte_0x0b"),

--- a/mh/pat_item.py
+++ b/mh/pat_item.py
@@ -579,8 +579,8 @@ class UserSearchInfo(PatData):
         (0x08, "server_name"),
         (0x0b, "unk_byte_0x0b"),
         (0x0c, "unk_string_0x0c"),
-        (0x0d, "city_size"),
-        (0x0e, "city_capacity"),
+        (0x0d, "city_capacity"),
+        (0x0e, "city_size"),
         (0x0f, "info_mine_0x0f"),
         (0x10, "info_mine_0x10"),
     )

--- a/mh/pat_item.py
+++ b/mh/pat_item.py
@@ -22,7 +22,7 @@
 import struct
 
 from collections import OrderedDict
-from other.utils import to_bytearray, get_config, get_ip
+from other.utils import to_bytearray, get_config, get_ip, GenericUnpacker
 
 
 class ItemType:
@@ -352,6 +352,11 @@ class FallthroughBug(Custom):
     """
     def __new__(cls):
         return Custom.__new__(cls, b"\xff", b"\xff")
+
+
+def pack_bytes(*args):
+    """Pack bytes list."""
+    return struct.pack(">B", len(args)) + bytearray(args)
 
 
 def unpack_bytes(data, offset=0):
@@ -708,6 +713,30 @@ class LayerBinaryInfo(PatData):
         (0x02, "capcom_id"),
         (0x03, "hunter_name")
     )
+
+
+class Unpacker(GenericUnpacker):
+    """Simple PAT item unpacker.
+
+    TODO:
+     - Handle PatData unpacking
+    """
+    MAPPING = {
+        "struct": (struct.unpack_from, struct.pack),
+        "lp_string": (unpack_lp_string, lp_string),
+        "lp2_string": (unpack_lp2_string, lp2_string),
+        "byte": (unpack_byte, pack_byte),
+        "word": (unpack_word, pack_word),
+        "long": (unpack_long, pack_long),
+        "longlong": (unpack_longlong, pack_longlong),
+        "string": (unpack_string, pack_string),
+        "binary": (unpack_binary, pack_binary),
+        "bytes": (unpack_bytes, pack_bytes),
+        "optional_fields": (unpack_optional_fields,
+                            pack_optional_fields),
+        "detailed_optional_fields": (unpack_detailed_optional_fields,
+                                     pack_detailed_optional_fields)
+    }
 
 
 class HunterSettings(object):

--- a/mh/session.py
+++ b/mh/session.py
@@ -194,6 +194,11 @@ class Session(object):
         start = first_index - 1
         return players[start:start+count]
 
+    def find_users(self, capcom_id, hunter_name, first_index, count):
+        users = DB.find_users(capcom_id, hunter_name)
+        start = first_index - 1
+        return users[start:start+count]
+
     def leave_server(self):
         DB.leave_server(self)
 

--- a/mh/session.py
+++ b/mh/session.py
@@ -44,6 +44,8 @@ class Session(object):
             "gate_name": None,
             "city_id": None,
             "city_name": None,
+            "city_size": 0,
+            "city_capacity": 0,
             "circle_id": None,
         }
         self.connection = connection_handler

--- a/mh/session.py
+++ b/mh/session.py
@@ -181,8 +181,16 @@ class Session(object):
             return self.get_cities()
         assert False, "Unsupported layer to get sibling"
 
-    def get_layer_users(self, server_id, gate_id, city_id, first_index, count):
-        players = list(DB.get_city(server_id, gate_id, city_id).players)
+    def find_users_by_layer(self, server_id, gate_id, city_id,
+                            first_index, count, recursive=False):
+        if recursive:
+            players = DB.get_all_users(server_id, gate_id, city_id)
+        else:
+            layer = \
+                DB.get_city(server_id, gate_id, city_id) if city_id else \
+                DB.get_gate(server_id, gate_id) if gate_id else \
+                DB.get_server(server_id)
+            players = list(layer.players)
         start = first_index - 1
         return players[start:start+count]
 

--- a/mh/session.py
+++ b/mh/session.py
@@ -19,6 +19,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import struct
+
 import mh.database as db
 import mh.pat_item as pati
 
@@ -233,3 +235,23 @@ class Session(object):
             return city.players
         else:
             assert False, "Can't find layer"
+
+    def get_layer_host_data(self):
+        """LayerUserInfo's layer_host."""
+        return struct.pack("IIHHH",
+                           3,  # layer depth?
+                           self.local_info["server_id"] or 0,
+                           1,  # ???
+                           self.local_info["gate_id"] or 0,
+                           self.local_info["city_id"] or 0)
+
+    def get_optional_fields(self):
+        """LayerUserInfo's optional fields."""
+        location = 1  # TODO: Don't hardcode location (city, quest, ...)
+        hunter_rank, = struct.unpack_from(">H", self.hunter_info.data, 0)
+        weapon_icon, = struct.unpack_from(">B", self.hunter_info.data, 0x10)
+        weapon_icon -= 7  # Skip armor pieces and start at index zero
+        return [
+                (1, (weapon_icon << 24) | location),
+                (2, hunter_rank << 16)
+        ]


### PR DESCRIPTION
This PR implements the packets used in the `Online > Player Search` menu. I also added an `Unpacker` helper class and fixed some stuff here and there.

What this PR doesn't do:
 - Implement some of the already missing/dummy data fields (the city size/capacity)
 - Implement/save the player location (in city/quest)
 - Implement the warp system
 - Implement the friendlist/friend packets
 - (...)

This PR should be ready to be tested.