### PR TITLE
Database: Fix Capcom ID creation

### DIFF
--- a/mh/database.py
+++ b/mh/database.py
@@ -265,6 +265,7 @@ class TempDatabase(object):
         while users[index] == "******":
             capcom_id = new_random_str(6)
             if capcom_id not in self.capcom_ids:
+                self.capcom_ids[capcom_id] = {"name": name, "session": None}
                 users[index] = capcom_id
                 break
         else:


### PR DESCRIPTION
This PR fixes an assertion error which spotted an issue in the Capcom ID creation. This assertion happens when you select an empty user slot.

Ready to be reviewed & merged.