### PR TITLE
Track the session state

### DIFF
--- a/fmp_server.py
+++ b/fmp_server.py
@@ -526,14 +526,12 @@ class FmpRequestHandler(PatRequestHandler):
 
         circle = city.circles[circle_index-1]
 
-        if circle.get_population() >= circle.get_capacity():
+        player_index = circle.players.add(self.session)
+        if player_index == -1:  # Circle is full
             self.sendAnsCircleJoin(0, 0, seq)
             return
 
-        player_index = circle.players.add(self.session)
-        assert player_index != -1, "Circle is full"
         self.session.join_circle(circle_index-1)
-
         self.sendAnsCircleJoin(circle_index, player_index+1, seq)
 
     def sendAnsCircleJoin(self, circle_index, player_index, seq):

--- a/fmp_server.py
+++ b/fmp_server.py
@@ -465,6 +465,12 @@ class FmpRequestHandler(PatRequestHandler):
         JP: マッチングオプション設定返答
         TR: Match option settings response
         """
+
+        is_standby = 'is_standby' in options and \
+            pati.unpack_byte(options.is_standby) == 1
+
+        self.session.set_circle_standby(is_standby)
+
         circle = self.session.get_circle()
         options.capcom_id = pati.String(self.session.capcom_id)
         options.hunter_name = pati.String(self.session.hunter_name)
@@ -582,7 +588,8 @@ class FmpRequestHandler(PatRequestHandler):
         data = struct.pack(">I", circle.get_population())
         for i, player in circle.players:
             circle_user_data = pati.CircleUserData()
-            circle_user_data.is_standby = pati.Byte(0)
+            circle_user_data.is_standby = pati.Byte(
+                int(player.is_circle_standby()))
             circle_user_data.player_index = pati.Byte(i+1)
             circle_user_data.capcom_id = pati.String(player.capcom_id)
             circle_user_data.hunter_name = pati.String(player.hunter_name)

--- a/fmp_server.py
+++ b/fmp_server.py
@@ -544,21 +544,21 @@ class FmpRequestHandler(PatRequestHandler):
         data = struct.pack(">IB", circle_index, player_index)
         self.send_packet(PatID4.AnsCircleJoin, data, seq)
 
-        if circle_index > 0:
-            city = self.session.get_city()
-            circle = city.circles[circle_index-1]
-            ntc_data = struct.pack(">I", circle_index)
-            ntc_data += pati.lp2_string(
-                self.session.capcom_id)
-            ntc_data += pati.lp2_string(
-                self.session.hunter_name)
+        if circle_index < 1:
+            return
 
-            # If state == 2 it increment a variable on NetworkSessionManagerPat
-            state = 0
+        city = self.session.get_city()
+        circle = city.circles[circle_index-1]
+        ntc_data = struct.pack(">I", circle_index)
+        ntc_data += pati.lp2_string(self.session.capcom_id)
+        ntc_data += pati.lp2_string(self.session.hunter_name)
 
-            ntc_data += struct.pack(">BB", player_index, state)
-            self.server.circle_broadcast(circle, PatID4.NtcCircleJoin,
-                                         ntc_data, seq, self.session)
+        # If state == 2 it increment a variable on NetworkSessionManagerPat
+        state = 0
+
+        ntc_data += struct.pack(">BB", player_index, state)
+        self.server.circle_broadcast(circle, PatID4.NtcCircleJoin, ntc_data,
+                                     seq, self.session)
 
     def recvReqCircleUserList(self, packet_id, data, seq):
         """ReqCircleUserList packet.

--- a/mh/database.py
+++ b/mh/database.py
@@ -85,6 +85,14 @@ class Players(object):
         if self.used < 1:
             return False
 
+        if isinstance(item, int):
+            if item >= self.get_capacity():
+                return False
+
+            self.slots[item] = None
+            self.used -= 1
+            return True
+
         for i, v in enumerate(self.slots):
             if v != item:
                 continue


### PR DESCRIPTION
We needed to track the session (player) a little bit with more detail, so I came up with this idea. But to be honest, after implementing it, I'm not too exited about it. Maybe there is better/simpler way?

Anyway, this allow me to fix two things:
- Previously, if someone created a circle and someone joined the circle and set himself as ready (standby), but another player joined after him, that other player wouldn't be able to see him (when in-quest) because the second player was ready (standby) before the third joined the circle. In other words, we weren't communicating the players that were ready, before you joined.
- Previously, we were sending to the circle's quest, everyone who enlisted in the circle ignoring if they were ready (standby) or not.

fix #41 