### PR TITLE
Circle password

### DIFF
--- a/fmp_server.py
+++ b/fmp_server.py
@@ -532,6 +532,13 @@ class FmpRequestHandler(PatRequestHandler):
 
         circle = city.circles[circle_index-1]
 
+        if circle.has_password() and ("password" not in circle_info or
+                                      pati.unpack_string(circle_info.password)
+                                      != circle.password):
+            self.sendAnsAlert(PatID4.AnsCircleJoin,
+                              "<LF=8><BODY><CENTER>Wrong Password!<END>", seq)
+            return
+
         player_index = circle.players.add(self.session)
         if player_index == -1:  # Circle is full
             self.sendAnsCircleJoin(0, 0, seq)

--- a/fmp_server.py
+++ b/fmp_server.py
@@ -540,8 +540,9 @@ class FmpRequestHandler(PatRequestHandler):
             return
 
         player_index = circle.players.add(self.session)
-        if player_index == -1:  # Circle is full
-            self.sendAnsCircleJoin(0, 0, seq)
+        if player_index == -1:
+            self.sendAnsAlert(PatID4.AnsCircleJoin,
+                              "<LF=8><BODY><CENTER>Quest is full!<END>", seq)
             return
 
         self.session.join_circle(circle_index-1)
@@ -554,11 +555,10 @@ class FmpRequestHandler(PatRequestHandler):
         JP: サークルイン返答
         TR: Circle-in reply
         """
+        assert circle_index > 0 and player_index > 0
+
         data = struct.pack(">IB", circle_index, player_index)
         self.send_packet(PatID4.AnsCircleJoin, data, seq)
-
-        if circle_index < 1:
-            return
 
         city = self.session.get_city()
         circle = city.circles[circle_index-1]

--- a/mh/pat.py
+++ b/mh/pat.py
@@ -130,6 +130,22 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
             packet_id, seq, hexdump(data)
         )
 
+    def sendAnsNg(self, packet_id, message, seq):
+        unk1 = 1  # If value is 0, the message is not rendered
+        data = struct.pack(">I", unk1)
+        data += pati.lp2_string(message)
+
+        packet_id = packet_id | 0xff
+        self.send_packet(packet_id, data, seq)
+
+    def sendAnsAlert(self, packet_id, message, seq):
+        unk1 = 1  # If value is 0, the message is not rendered
+        data = struct.pack(">I", unk1)
+        data += pati.lp2_string(message)
+
+        packet_id = packet_id | 0x01
+        self.send_packet(packet_id, data, seq)
+
     def send_error(self, message, seq=0):
         """Send an error message."""
         try:


### PR DESCRIPTION
Previously, when leader of a circle (quest) set a password, we weren't verifying it when another player joined the circle.

![image](https://user-images.githubusercontent.com/2200611/166116805-b987261b-5165-4177-be3c-b7ee568c67c5.png)

Also, we now have a proper method of communicating with the client a non-fatal error message