### PR TITLE
Properly propagate changes in the circle's member collection

### DIFF
--- a/fmp_server.py
+++ b/fmp_server.py
@@ -411,10 +411,6 @@ class FmpRequestHandler(PatRequestHandler):
         if "remarks" in circle_info:
             circle.remarks = pati.unpack_string(circle_info.remarks)
 
-        if "party_members" in circle_info:
-            circle.party_member_binary = \
-                pati.unpack_binary(circle_info.party_members)
-
         if "unk_byte_0x0e" in circle_info:
             circle.unk_byte_0x0e = pati.unpack_byte(circle_info.unk_byte_0x0e)
 
@@ -790,11 +786,6 @@ class FmpRequestHandler(PatRequestHandler):
 
         city = self.session.get_city()
         circle = city.circles[circle_index-1]
-
-        # TODO: Set other fields too, find how to trigger them
-        if "party_members" in circle_info:
-            circle.party_member_binary = pati.unpack_binary(
-                circle_info.party_members)
 
         self.sendAnsCircleInfoSet(circle_index, circle_info, optional_fields,
                                   seq)

--- a/fmp_server.py
+++ b/fmp_server.py
@@ -843,6 +843,7 @@ class FmpRequestHandler(PatRequestHandler):
         circle.departed = True
 
         count = 0
+        changed = False
         data = b''
         for i, player in circle.players:
             if player.is_circle_standby():
@@ -858,6 +859,7 @@ class FmpRequestHandler(PatRequestHandler):
                 pat_handler.send_packet(PatID4.NtcCircleKick, ntc_circle_kick,
                                         seq)
                 circle.players.remove(i)
+                changed = True
 
         data = struct.pack(">I", count)+data
         data = struct.pack(">H", len(data))+data
@@ -865,6 +867,10 @@ class FmpRequestHandler(PatRequestHandler):
 
         self.server.circle_broadcast(circle, PatID4.NtcCircleMatchStart, data,
                                      seq)
+
+        if changed:
+            circle_index = circle.parent.circles.index(circle) + 1
+            self.sendNtcCircleListLayerChange(circle, circle_index, seq)
 
     def recvReqCircleMatchEnd(self, packet_id, data, seq):
         """ReqCircleMatchEnd packet.

--- a/mh/database.py
+++ b/mh/database.py
@@ -161,7 +161,6 @@ class Circle(object):
         self.remarks = None
 
         self.unk_byte_0x0e = 0
-        self.party_member_binary = None
 
     def get_population(self):
         return len(self.players)
@@ -191,7 +190,6 @@ class Circle(object):
         self.remarks = None
 
         self.unk_byte_0x0e = 0
-        self.party_member_binary = None
 
 
 class City(object):


### PR DESCRIPTION
We now have the capability to properly serialize our self the member of a circle. That way when we made changes to the collection of participant of a circle, we can send the changes without waiting for the circle's leader to acknowledge the changes himself.

For now, we only fix the case were if somebody is left behind (because he/she wasn't ready) when departing for a quest, we propagate the change correctly.

Other fixed would come after we properly detect and cleanup when somebody disconnect