### PR TITLE
Properly shutdown when requested

### DIFF
--- a/mh/pat.py
+++ b/mh/pat.py
@@ -2395,9 +2395,6 @@ class PatRequestHandler(SocketServer.StreamRequestHandler):
         self.server.add_to_debug(self)
         self.session = Session(self)
 
-        # There are connect errors if too fast
-        # TODO: investigate if it's Dolphin's fault
-        time.sleep(2)
         self.sendReqConnection()
         try:
             self.handle_client()


### PR DESCRIPTION
Previously weren't shutting down the `StreamRequestHandler` when sending `AnsShut`/`NtcShut`. This caused problems because when the handler was going to loop back and `::select` the socket, it was closed by the client (requested by us) causing the system to throw an exception that wouldn't be handled, This in-turn caused that the `session`'s resources weren't being saved/free properly.