### PR TITLE
Add legacy SSL ciphers support

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,7 @@
 [SSL]
 DefaultCert = cert/server.crt
 DefaultKey = cert/server.key
+LegacySSL = OFF
 
 [OPN]
 IP = 0.0.0.0


### PR DESCRIPTION
This PR fixes issues related to SSL security being too weak. It targets the master branch as some users are concerned especially when running the server on recent OS and Linux distributions. I chose to disable the option by default since I don't think it's a good idea to bypass existing security policies and people doing so should be aware of that.

Ready to reviewed & merged.