### PR TITLE
City creation and joining bug

### DIFF
--- a/mh/pat.py
+++ b/mh/pat.py
@@ -2198,6 +2198,12 @@ class PatRequestHandler(SocketServer.StreamRequestHandler, object):
         TR: Layer creation response
         """
         data = struct.pack(">H", number)
+        if not self.session.is_city_empty(number):
+            self.sendAnsAlert(PatID4.AnsLayerCreateHead, "<LF=8><BODY><CENTER>City already exists.<END>", seq)
+            return
+        if not self.session.reserve_city(number, True):
+            self.sendAnsAlert(PatID4.AnsLayerCreateHead, "<LF=8><BODY><CENTER>City reserved.<END>", seq)
+            return
         self.send_packet(PatID4.AnsLayerCreateHead, data, seq)
 
     def recvReqLayerCreateSet(self, packet_id, data, seq):
@@ -2234,6 +2240,7 @@ class PatRequestHandler(SocketServer.StreamRequestHandler, object):
         TR: Layer creation end of transmission request
         """
         number, unk = struct.unpack(">HB", data)
+        self.session.reserve_city(number, False)
         self.sendAnsLayerCreateFoot(number, unk, seq)
 
     def sendAnsLayerCreateFoot(self, number, unk, seq):

--- a/mh/session.py
+++ b/mh/session.py
@@ -240,6 +240,12 @@ class Session(object):
         return DB.get_cities(self.local_info["server_id"],
                              self.local_info["gate_id"])
 
+    def is_city_empty(self, city_id):
+        return DB.get_city(self.local_info["server_id"], self.local_info["gate_id"], city_id).get_state() == db.LayerState.EMPTY
+
+    def reserve_city(self, city_id, reserve):
+        return DB.reserve_city(self.local_info["server_id"], self.local_info["gate_id"], city_id, reserve)
+
     def create_city(self, city_id, settings, optional_fields):
         return DB.create_city(self,
                               self.local_info["server_id"],


### PR DESCRIPTION
Added code to prevent the creation of invalid cities.
This included cities that already exist, or are already reserved by another user in the city creation menu.

This would fix, among others, the bug pictured below.

![image](https://user-images.githubusercontent.com/24629810/187835710-fabde075-f491-463e-810b-08425b1456b5.png)

This does NOT implement city list refreshing. It simply removes the more severe consequences of the city list not refreshing, such as server/client crashes and layer misplacement.
