### PR TITLE
Allow all supported SSL protocols

### DIFF
--- a/other/utils.py
+++ b/other/utils.py
@@ -253,7 +253,10 @@ def create_server(server_class, server_handler,
     if use_ssl:
         import ssl
 
-        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        if hasattr(ssl, "TLSVersion"):  # Since Python 3.7
+            # Required since Python 3.10
+            context.minimum_version = ssl.TLSVersion.SSLv3
         wii_ciphers = ":".join([
             "AES128-SHA", "AES256-SHA",
             # The following ones are often unavailable


### PR DESCRIPTION
Not sure why enforcing TLSv1 work in some cases and don't in others for some people. Switching this PR as draft while I make sure it doesn't cause a regression from all my testing devices (i.e. Dolphin/real Wii and VPS/local server).