### PR TITLE
Added time passing and 14-day cycle for Jhen event

### DIFF
--- a/mh/constants.py
+++ b/mh/constants.py
@@ -21,19 +21,14 @@
 
 import struct
 from other.utils import pad
+from mh.time_utils import current_tick, TICKS_PER_CYCLE, get_jhen_event_times
 from quest_utils import QUEST_EVENT_JUMP_FOUR_JAGGI, QUEST_EVENT_BLOOD_SPORT,\
     QUEST_EVENT_MERCY_MISSION, QUEST_EVENT_THE_PHANTOM_URAGAAN, QUEST_EVENT_WORLD_EATER,\
     QUEST_EVENT_WHERE_GODS_FEAR_TO_TREAD, QUEST_EVENT_GREEN_EGGS
 
 
-def make_binary_type_time_events(state=0):
-    # TODO: Use the server in-game time and handle this time array properly
-    if state == 1:
-        return struct.pack(">iii", 0, -1, 0)  # Fog
-    elif state == 2:
-        return struct.pack(">iii", 0, 0, -1)  # Kujira
-    else:
-        return struct.pack(">iii", 0, 0, 0)
+def make_binary_type_time_events():
+    return struct.pack(">III", *get_jhen_event_times())
 
 
 def make_binary_server_type_list(is_jap=False):
@@ -59,8 +54,9 @@ def make_binary_server_type_list(is_jap=False):
                 desc[i:i+1] = b' ' * padding
         data += pad(desc, 112 if is_jap else 168)
 
-    # TODO: Figure out what it is
-    data += b"\0" * 12
+    data += struct.pack(">I", 0)  # unk
+    data += struct.pack(">I", current_tick())  # Current time tick, counts backwards
+    data += struct.pack(">I", TICKS_PER_CYCLE)  # Max Tick Per Cycle, if 0 game defaults to 3000
 
     # Handle city seekings (x32)
     SEEKINGS = [
@@ -259,11 +255,11 @@ OTHER_HUNTER_NAME = b"Drakea"
 PAT_BINARIES = {
     0x01: {
         "version": 1,
-        "content": make_binary_server_type_list(is_jap=IS_JAP)
+        "content": lambda: make_binary_server_type_list(is_jap=IS_JAP)
     },
     0x02: {
         "version": 1,
-        "content": make_binary_type_time_events(state=TIME_STATE)
+        "content": make_binary_type_time_events
     },
     0x03: {
         "version": 1,
@@ -321,11 +317,11 @@ PAT_BINARIES = {
     },
     0x10: {  # French
         "version": 1,
-        "content": make_binary_server_type_list()
+        "content": make_binary_server_type_list
     },
     0x11: {  # French
         "version": 1,
-        "content": make_binary_type_time_events(state=TIME_STATE)
+        "content": make_binary_type_time_events
     },
     0x12: {  # French
         "version": 1,
@@ -381,11 +377,11 @@ PAT_BINARIES = {
     },
     0x1f: {  # German
         "version": 1,
-        "content": make_binary_server_type_list()
+        "content": make_binary_server_type_list
     },
     0x20: {  # German
         "version": 1,
-        "content": make_binary_type_time_events(state=TIME_STATE)
+        "content": make_binary_type_time_events
     },
     0x21: {  # German
         "version": 1,
@@ -441,11 +437,11 @@ PAT_BINARIES = {
     },
     0x2e: {  # Italian
         "version": 1,
-        "content": make_binary_server_type_list()
+        "content": make_binary_server_type_list
     },
     0x2f: {  # Italian
         "version": 1,
-        "content": make_binary_type_time_events(state=TIME_STATE)
+        "content": make_binary_type_time_events
     },
     0x30: {  # Italian
         "version": 1,
@@ -501,11 +497,11 @@ PAT_BINARIES = {
     },
     0x3d: {  # Spanish
         "version": 1,
-        "content": make_binary_server_type_list()
+        "content": make_binary_server_type_list
     },
     0x3e: {  # Spanish
         "version": 1,
-        "content": make_binary_type_time_events(state=TIME_STATE)
+        "content": make_binary_type_time_events
     },
     0x3f: {  # Spanish
         "version": 1,

--- a/mh/time_utils.py
+++ b/mh/time_utils.py
@@ -21,8 +21,64 @@
 
 import datetime
 
+
 EPOCH = datetime.datetime(1970, 1, 1)
+TICKS_PER_CYCLE = 23040  # 6.4 hours per cycle, 3.2 hours per daytime/nighttime
+
+SECONDS_PER_DAY = 24*60*60
+JHEN_EVENT_OFFSET = 14  # Cycle of 14 (real) days
+FOG_START = 0
+JHEN_START = 1  # 1 (real) day of fog
+JHEN_END = 3  # Followed by 2 (real) days of sandstorm
 
 
 def datetime_to_int(dt):
     return int((dt - EPOCH).total_seconds())
+
+
+def current_tick():
+    """
+    This product of this function is based on the assumption that
+    any decreasing integer value is sufficient for tracking the
+    passage of time in Monster Hunter Tri.
+    
+    Debugging has shown that the internal time value (initialized
+    via a request to the server which responds using this function)
+    continuously decreases by one per second, and an internal modulus
+    is used to turn the ever-decreasing value into a point in the
+    day/night cycle (with a cycle length specified by the server).
+    
+    It is also suspected that, should this value ever reach zero, an
+    integer underflow happens, which disrupts the day/night cycle.
+    
+    As a result, to ensure that the underflow never happens, the current
+    implementation uses a reversed epoch time that counts down from
+    UINT_MAX (the game's internal maximum for this value) as the seconds
+    pass. This also has the effect of time "passing" even when the
+    server is shut down.
+    """
+    return 0xFFFFFFFF - datetime_to_int(datetime.datetime.now())
+
+
+def current_server_time():
+    return datetime_to_int(datetime.datetime.now())
+
+
+def get_jhen_event_times():
+    """
+    If the first int is less than the gametime at server login:
+      If the second int is greater than the gametime at server login, fog
+      Otherwise, if the third int is greater than the gametime at server login, sandstorm
+    FIRST INT: Start of fog (epoch seconds)
+    SECOND INT: Start of Jhen event (epoch seconds)
+    THIRD INT: End of Jhen event (epoch seconds)
+    """
+    current_day = int(current_server_time()//SECONDS_PER_DAY)
+    day_in_cycle = current_day % JHEN_EVENT_OFFSET
+    if day_in_cycle < JHEN_END:  # Current period
+        cycle_start = (current_day - day_in_cycle) * SECONDS_PER_DAY
+    else:  # Upcoming period
+        cycle_start = (current_day - day_in_cycle + JHEN_EVENT_OFFSET) * SECONDS_PER_DAY
+    return (int(cycle_start + FOG_START*SECONDS_PER_DAY),  # fog start
+            int(cycle_start + JHEN_START*SECONDS_PER_DAY),  # sandstorm start
+            int(cycle_start + JHEN_END*SECONDS_PER_DAY))  # sandstorm end


### PR DESCRIPTION
Implemented serverside timers for day cycle ticks (counts backwards from epoch time) as well as server time (counts forwards from epoch time).

Also implemented cyclical Jhen Mohran event, which is based on server time and repeats every 14 days. This cycle starts with 1 day of fog followed by 2 days of sandstorm, and then 11 days of calm before repeating.