### PR TITLE
Added client timeout & debug mode that disables it

### DIFF
--- a/master_server.py
+++ b/master_server.py
@@ -29,13 +29,14 @@ import rfp_server as RFP
 from other.utils import create_server_from_base
 
 
-def create_servers(silent=False):
+def create_servers(silent=False, debug_mode=False):
     """Create servers and check if it has ui."""
     servers = []
     has_ui = False
     for module in (OPN, LMP, FMP, RFP):
         server, has_window = create_server_from_base(*module.BASE,
-                                                     silent=silent)
+                                                     silent=silent,
+                                                     debug_mode=debug_mode)
         has_ui = has_ui or has_window
         servers.append(server)
     return servers, has_ui
@@ -43,7 +44,8 @@ def create_servers(silent=False):
 
 def main(args):
     """Master server main function."""
-    servers, has_ui = create_servers(silent=args.silent)
+    servers, has_ui = create_servers(silent=args.silent,
+                                     debug_mode=args.debug_mode)
     threads = [
         threading.Thread(target=server.serve_forever)
         for server in servers
@@ -93,5 +95,9 @@ if __name__ == "__main__":
     parser.add_argument("-s", "--silent", action="store_true",
                         dest="silent",
                         help="silent console logs")
+    parser.add_argument("-d", "--debug_mode", action="store_true",
+                        dest="debug_mode",
+                        help="enable debug mode, disabling timeouts and \
+                        lower logging verbosity level")
     args = parser.parse_args()
     main(args)

--- a/other/utils.py
+++ b/other/utils.py
@@ -319,14 +319,15 @@ def create_server(server_class, server_handler,
                   address="0.0.0.0", port=8200, name="Server",
                   use_ssl=True, ssl_cert="server.crt", ssl_key="server.key",
                   log_to_file=True, log_filename="server.log",
-                  log_to_console=True, log_to_window=False, legacy_ssl=False):
+                  log_to_console=True, log_to_window=False, legacy_ssl=False,
+                  debug_mode=False):
     """Create a server, its logger and the SSL context if needed."""
     logger = create_logger(
-        name, level=logging.DEBUG,
+        name, level=logging.DEBUG if debug_mode else logging.INFO,
         log_to_file=log_filename if log_to_file else "",
         log_to_console=log_to_console,
         log_to_window=log_to_window)
-    server = server_class((address, port), server_handler, logger)
+    server = server_class((address, port), server_handler, logger, debug_mode)
 
     if use_ssl:
         import ssl
@@ -343,7 +344,8 @@ def create_server(server_class, server_handler,
 server_base = namedtuple("ServerBase", ["name", "cls", "handler"])
 
 
-def create_server_from_base(name, server_class, server_handler, silent=False):
+def create_server_from_base(name, server_class, server_handler, silent=False,
+                            debug_mode=False):
     """Create a server based on its config parameters."""
     config = get_config(name)
     return create_server(
@@ -358,7 +360,8 @@ def create_server_from_base(name, server_class, server_handler, silent=False):
         log_to_file=config["LogToFile"],
         log_filename=config["LogFilename"],
         log_to_console=config["LogToConsole"] and not silent,
-        log_to_window=config["LogToWindow"]
+        log_to_window=config["LogToWindow"],
+        debug_mode=debug_mode
     ), config["LogToWindow"]
 
 


### PR DESCRIPTION
- Added client timeout that disconnects a player and clears them from the server if they do not respond to a `LineCheck` packet in time
This has the effect of removing "stuck" players or "ghost" players who disconnected through strange means (such as internet going down) and would otherwise have their characters trapped in the server with their Capcom ID stuck in use.

- Added debug mode that disables the timeout
Since pausing Dolphin and looking through the active memory is such a huge part of this server's development, I implemented a "debug mode" that can be enabled through a launch argument `-d` or `--debug_mode` that disables the timeout and thus allows a developer to pause Dolphin for extended periods without getting disconnected.