### PR TITLE
Added dynamically updating greeter text

### DIFF
--- a/mh/constants.py
+++ b/mh/constants.py
@@ -21,10 +21,11 @@
 
 import struct
 from other.utils import pad
-from mh.time_utils import current_tick, TICKS_PER_CYCLE, get_jhen_event_times
+from mh.time_utils import current_tick, TICKS_PER_CYCLE, get_jhen_event_times,\
+    is_jhen_active
 from mh.quest_utils import QUEST_EVENT_JUMP_FOUR_JAGGI, QUEST_EVENT_BLOOD_SPORT,\
     QUEST_EVENT_MERCY_MISSION, QUEST_EVENT_THE_PHANTOM_URAGAAN, QUEST_EVENT_WORLD_EATER,\
-    QUEST_EVENT_WHERE_GODS_FEAR_TO_TREAD, QUEST_EVENT_GREEN_EGGS
+    QUEST_EVENT_WHERE_GODS_FEAR_TO_TREAD, QUEST_EVENT_GREEN_EGGS, get_quest_name
 
 
 def make_binary_type_time_events():
@@ -164,13 +165,45 @@ def make_binary_npc_greeters(is_jap=False):
     US_OFFSET = 0x180
     JP_OFFSET = 0x100
     offset = JP_OFFSET if is_jap else US_OFFSET
+
+
+    if is_jhen_active():
+        tool_shop = b"Half-off sale!"
+        material_shop = b"Half-off sale!"
+        event_quests = b"The Festival of Fear\n"
+    else:
+        tool_shop = b"Prices are normal."
+        material_shop = b"Prices are normal."
+        event_quests = b""
+
+    event_quests += b"\n".join([
+        get_quest_name(QUEST_EVENT_JUMP_FOUR_JAGGI),
+        get_quest_name(QUEST_EVENT_BLOOD_SPORT),
+        get_quest_name(QUEST_EVENT_MERCY_MISSION),
+        get_quest_name(QUEST_EVENT_THE_PHANTOM_URAGAAN),
+        get_quest_name(QUEST_EVENT_WORLD_EATER),
+        get_quest_name(QUEST_EVENT_WHERE_GODS_FEAR_TO_TREAD),
+        get_quest_name(QUEST_EVENT_GREEN_EGGS)
+    ])
+
+    guildmaster_str = (
+        b'To all hunters:\n'
+        b'Loc Lac is in "beta,"\n'
+        b'whatever that means. Also,\n'
+        b'the Arena is currently under\n'
+        b'construction. And now, a:\n'
+        b'haiku: "Patient warriors /\n'    
+        b'returning home at long last /\n'
+        b'now join hands to hunt!"'
+    )
+
     data = b""
-    data += pad(b"Plaza Tool Shop\n\nNot supported yet.", offset)
-    data += pad(b"Material shop unavailable\nyet.", offset)
-    data += pad(b"Trading post closed at\nthe moment.", offset)
-    data += pad(b"No event quests.", offset)
+    data += pad(tool_shop, offset)
+    data += pad(material_shop, offset)
+    data += pad(b"The Trading Post is open!", offset)
+    data += pad(event_quests, offset)
     data += pad(b"No arena quests.", offset)
-    data += pad(b"To all hunters:\n\nThis is a test server.", offset)
+    data += pad(guildmaster_str, offset)
     return data
 
 
@@ -260,7 +293,7 @@ PAT_BINARIES = {
     },
     0x03: {
         "version": 1,
-        "content": make_binary_npc_greeters(is_jap=IS_JAP)
+        "content": lambda: make_binary_npc_greeters(is_jap=IS_JAP)
     },
     0x04: {
         "version": 1,
@@ -322,7 +355,7 @@ PAT_BINARIES = {
     },
     0x12: {  # French
         "version": 1,
-        "content": make_binary_npc_greeters()
+        "content": make_binary_npc_greeters
     },
     0x13: {  # French
         "version": 1,
@@ -382,7 +415,7 @@ PAT_BINARIES = {
     },
     0x21: {  # German
         "version": 1,
-        "content": make_binary_npc_greeters()
+        "content": make_binary_npc_greeters
     },
     0x22: {  # German
         "version": 1,
@@ -442,7 +475,7 @@ PAT_BINARIES = {
     },
     0x30: {  # Italian
         "version": 1,
-        "content": make_binary_npc_greeters()
+        "content": make_binary_npc_greeters
     },
     0x31: {  # Italian
         "version": 1,
@@ -502,7 +535,7 @@ PAT_BINARIES = {
     },
     0x3f: {  # Spanish
         "version": 1,
-        "content": make_binary_npc_greeters()
+        "content": make_binary_npc_greeters
     },
     0x40: {  # Spanish
         "version": 1,

--- a/mh/quest_utils.py
+++ b/mh/quest_utils.py
@@ -20,6 +20,7 @@
 """
 
 import struct
+import ctypes
 from other.utils import pad
 
 
@@ -1324,6 +1325,13 @@ def read_quest_sm_data(fname):
     with open('event/'+fname) as f:
         data = f.read()
     return bytearray.fromhex(data.replace(" ","").replace("\n",""))
+
+def get_quest_name(quest):
+    """
+    Returns the quest name, which is always a null-terminated
+    string that starts at offset 0.
+    """
+    return ctypes.create_string_buffer(bytes(quest)).value
 
 
 """

--- a/mh/time_utils.py
+++ b/mh/time_utils.py
@@ -87,6 +87,11 @@ def get_jhen_event_times():
             int(cycle_start + JHEN_END*SECONDS_PER_DAY))  # sandstorm end
 
 
+def is_jhen_active():
+    day_in_cycle = int(current_server_time()//SECONDS_PER_DAY) % JHEN_EVENT_OFFSET
+    return JHEN_START <= day_in_cycle < JHEN_END
+
+
 class Timer(object):
     def __init__(self):
         self.__start = time.time()


### PR DESCRIPTION
Greeter text changes based on sandstorm status. This can be further updated to support automatically-changing event quests (and arena quests) once that feature is implemented. In the meantime, since they are hardcoded, the event quest names in the Greeter menu are hardcoded (with the exception of the Jhen event quest, which only appears if there is a sandstorm)