### PR TITLE
Fixed bug with incorrect player count in Servers

### DIFF
--- a/mh/pat.py
+++ b/mh/pat.py
@@ -187,6 +187,7 @@ class PatRequestHandler(server.BasicPatHandler):
             # Probably unreachable and was disconnected
             self.server.warning("Failed to send a complete error message")
         finally:
+            self.session.request_reconnection = False
             self.finish()
 
     def recvNtcCollectionLog(self, packet_id, data, seq):
@@ -598,6 +599,10 @@ class PatRequestHandler(server.BasicPatHandler):
         """
         data = struct.pack(">B", shutdown_type)
         self.send_packet(PatID4.AnsShut, data, seq)
+        if shutdown_type == 1:
+            # Only modify request_reconnection if it's a 1 shutdown_type,
+            # otherwise leave it at what it was before
+            self.session.request_reconnection = False
         self.finish()
 
     def sendNtcShut(self, message, seq):

--- a/mh/server.py
+++ b/mh/server.py
@@ -133,7 +133,7 @@ class BasicPatHandler(object):
 
         try:
             self.on_finish()
-        except Exception:
+        except Exception as e:
             pass
 
         self.finished = True

--- a/mh/session.py
+++ b/mh/session.py
@@ -172,6 +172,9 @@ class Session(object):
             if not self.request_reconnection:
                 # Server path (executed at gate and higher)
                 self.leave_server()
+        elif not self.request_reconnection and self.local_info["server_id"]:
+            # Server path (executed if exiting from gate list)
+            self.leave_server()
         self.layer = 0
         self.state = SessionState.UNKNOWN
 


### PR DESCRIPTION
Re-implemented logic based on the byte sent with the `ReqShut` packet, which, if 1, instructs the server to disconnect the player completely. It differentiates between when the client is switching from one server to another, and when the client is fully disconnecting from the game.

This fixes the bug where, when players disconnected from the screen that displays the list of gates in a server, they would not be removed from the list of players in the server. This resulted in an incorrect player count in the affected server.