### PR TITLE
Fixed time divergence issue

### DIFF
--- a/mh/constants.py
+++ b/mh/constants.py
@@ -21,7 +21,7 @@
 
 import struct
 from other.utils import pad
-from mh.time_utils import current_tick, TICKS_PER_CYCLE, get_jhen_event_times,\
+from mh.time_utils import current_server_time, TICKS_PER_CYCLE, get_jhen_event_times,\
     is_jhen_active
 from mh.quest_utils import QUEST_EVENT_JUMP_FOUR_JAGGI, QUEST_EVENT_BLOOD_SPORT,\
     QUEST_EVENT_MERCY_MISSION, QUEST_EVENT_THE_PHANTOM_URAGAAN, QUEST_EVENT_WORLD_EATER,\
@@ -56,7 +56,7 @@ def make_binary_server_type_list(is_jap=False):
         data += pad(desc, 112 if is_jap else 168)
 
     data += struct.pack(">I", 0)  # unk
-    data += struct.pack(">I", current_tick())  # Current time tick, counts backwards
+    data += struct.pack(">I", current_server_time())  # Current time at server bootup
     data += struct.pack(">I", TICKS_PER_CYCLE)  # Max Tick Per Cycle, if 0 game defaults to 3000
 
     # Handle city seekings (x32)
@@ -285,7 +285,7 @@ IS_JAP = False
 PAT_BINARIES = {
     0x01: {
         "version": 1,
-        "content": lambda: make_binary_server_type_list(is_jap=IS_JAP)
+        "content": make_binary_server_type_list(is_jap=IS_JAP)
     },
     0x02: {
         "version": 1,
@@ -347,7 +347,7 @@ PAT_BINARIES = {
     },
     0x10: {  # French
         "version": 1,
-        "content": make_binary_server_type_list
+        "content": make_binary_server_type_list()
     },
     0x11: {  # French
         "version": 1,
@@ -407,7 +407,7 @@ PAT_BINARIES = {
     },
     0x1f: {  # German
         "version": 1,
-        "content": make_binary_server_type_list
+        "content": make_binary_server_type_list()
     },
     0x20: {  # German
         "version": 1,
@@ -467,7 +467,7 @@ PAT_BINARIES = {
     },
     0x2e: {  # Italian
         "version": 1,
-        "content": make_binary_server_type_list
+        "content": make_binary_server_type_list()
     },
     0x2f: {  # Italian
         "version": 1,
@@ -527,7 +527,7 @@ PAT_BINARIES = {
     },
     0x3d: {  # Spanish
         "version": 1,
-        "content": make_binary_server_type_list
+        "content": make_binary_server_type_list()
     },
     0x3e: {  # Spanish
         "version": 1,

--- a/mh/time_utils.py
+++ b/mh/time_utils.py
@@ -37,30 +37,6 @@ def datetime_to_int(dt):
     return int((dt - EPOCH).total_seconds())
 
 
-def current_tick():
-    """
-    This product of this function is based on the assumption that
-    any decreasing integer value is sufficient for tracking the
-    passage of time in Monster Hunter Tri.
-
-    Debugging has shown that the internal time value (initialized
-    via a request to the server which responds using this function)
-    continuously decreases by one per second, and an internal modulus
-    is used to turn the ever-decreasing value into a point in the
-    day/night cycle (with a cycle length specified by the server).
-
-    It is also suspected that, should this value ever reach zero, an
-    integer underflow happens, which disrupts the day/night cycle.
-
-    As a result, to ensure that the underflow never happens, the current
-    implementation uses a reversed epoch time that counts down from
-    UINT_MAX (the game's internal maximum for this value) as the seconds
-    pass. This also has the effect of time "passing" even when the
-    server is shut down.
-    """
-    return 0xFFFFFFFF - datetime_to_int(datetime.datetime.now())
-
-
 def current_server_time():
     return datetime_to_int(datetime.datetime.now())
 


### PR DESCRIPTION
This PR fixes the issue where players who log in later than others have their times initialized ahead of everybody else.

This was caused due to the "countdown" that was previously used to advance time. With the addition of the time-based event quests, the correct timer now progresses forwards, making the countdown unneeded. The countdown has been replaced with a single variable set upon server initialization to the timestamp at which the server was booted up. As a consequence, the in-game day/night cycle will always start at the beginning of daytime when the server boots up.

If we wished to make the day/night cycle continuous even across periods when the server was off, like it was before, we could set the value to a constant timestamp instead.