### PR TITLE
PAT: Implement NtcLayerMediation packets

### DIFF
--- a/mh/pat_item.py
+++ b/mh/pat_item.py
@@ -665,9 +665,9 @@ class LayerSet(PatData):
 
 class MediationListItem(PatData):
     FIELDS = (
-        (0x01, "name"),
-        (0x02, "unk_byte_0x02"),
-        (0x03, "unk_byte_0x03"),
+        (0x01, "name"),  # name or owner?
+        (0x02, "index"),
+        (0x03, "is_locked"),  # 1 - locked, unlocked otherwise
     )
 
 


### PR DESCRIPTION
This PR implements the NtcLayerMediation packets properly. At the moment, I kept them disabled since the city doesn't retain the mediation list and it can produce oddities upon player disconnection or player entering the city.

Ready to be reviewed & merged.