### PR TITLE
Add message and friend list support

### DIFF
--- a/mh/database.py
+++ b/mh/database.py
@@ -695,6 +695,63 @@ class TempDatabase(object):
         ][begin:end]
 
 
+class DebugDatabase(TempDatabase):
+    """For testing purpose."""
+    def __init__(self, *args, **kwargs):
+        TempDatabase.__init__(self, *args, **kwargs)
+        self.consoles = {
+            # To use it, replace with a real support code
+            "TEST_CONSOLE_1": [
+                "AAAAAA", "BBBBBB", "CCCCCC", "DDDDDD", "EEEEEE", "FFFFFF"
+            ],
+            "TEST_CONSOLE_2": [
+                "111111", "222222", "333333", "444444", "555555", "666666"
+            ],
+        }
+        self.capcom_ids = {
+            "AAAAAA": {"name": b"Hunt A", "session": None},
+            "BBBBBB": {"name": b"Hunt B", "session": None},
+            "CCCCCC": {"name": b"Hunt C", "session": None},
+            "DDDDDD": {"name": b"Hunt D", "session": None},
+            "EEEEEE": {"name": b"Hunt E", "session": None},
+            "FFFFFF": {"name": b"Hunt F", "session": None},
+            "111111": {"name": b"Hunt 1", "session": None},
+            "222222": {"name": b"Hunt 2", "session": None},
+            "333333": {"name": b"Hunt 3", "session": None},
+            "444444": {"name": b"Hunt 4", "session": None},
+            "555555": {"name": b"Hunt 5", "session": None},
+            "666666": {"name": b"Hunt 6", "session": None},
+        }
+        self.friend_requests = {
+            "AAAAAA": [],
+            "BBBBBB": [],
+            "CCCCCC": [],
+            "DDDDDD": [],
+            "EEEEEE": [],
+            "FFFFFF": [],
+            "111111": [],
+            "222222": [],
+            "333333": [],
+            "444444": [],
+            "555555": [],
+            "666666": [],
+        }
+        self.friend_lists = {
+            "AAAAAA": [],
+            "BBBBBB": [],
+            "CCCCCC": [],
+            "DDDDDD": [],
+            "EEEEEE": [],
+            "FFFFFF": [],
+            "111111": [],
+            "222222": [],
+            "333333": [],
+            "444444": [],
+            "555555": [],
+            "666666": [],
+        }
+
+
 CURRENT_DB = TempDatabase()
 
 

--- a/mh/pat.py
+++ b/mh/pat.py
@@ -1264,9 +1264,15 @@ class PatRequestHandler(server.BasicPatHandler):
         JP: ユーザ検索データ返答
         TR: User search data response
         """
-        users = self.session.find_users(capcom_id, "", 1, 1)
-        assert users, "Capcom ID not found"
-        user = users[0]
+        user = self.session.find_user_by_capcom_id(capcom_id)
+        if not user:
+            # TODO: Find a better way to notify offline status in friend list
+            user_info = pati.UserSearchInfo()
+            user_info.capcom_id = pati.String(capcom_id)
+            user_info.hunter_name = pati.String("OFFLINE")
+            data = user_info.pack() + pati.pack_optional_fields([])
+            self.sendAnsAlert(PatID4.AnsUserSearchInfo, data, seq)
+            return
 
         user_info = pati.UserSearchInfo()
         user_info.capcom_id = pati.String(user.capcom_id)

--- a/mh/pat.py
+++ b/mh/pat.py
@@ -1163,7 +1163,7 @@ class PatRequestHandler(server.BasicPatHandler):
         """
         with pati.Unpacker(data) as unpacker:
             self.search_info = {
-                "capcom_id": unpacker.lp2_string(),
+                "capcom_id": to_str(unpacker.lp2_string()),
                 "hunter_name": unpacker.lp2_string(),
                 "search": unpacker.detailed_optional_fields(),
                 "offset": unpacker.struct(">I")[0],
@@ -1507,7 +1507,7 @@ class PatRequestHandler(server.BasicPatHandler):
             self.search_info = {
                 "unk": unpacker.struct(">B")[0],
                 "layer": unpacker.lp2_string(),
-                "capcom_id": unpacker.lp2_string(),
+                "capcom_id": to_str(unpacker.lp2_string()),
                 "hunter_name": unpacker.lp2_string(),
                 "search": unpacker.detailed_optional_fields(),
                 "offset": unpacker.struct(">I")[0],
@@ -1633,7 +1633,7 @@ class PatRequestHandler(server.BasicPatHandler):
         TODO: Implement it properly
         """
         with pati.Unpacker(data) as unpacker:
-            capcom_id = unpacker.lp2_string()
+            capcom_id = to_str(unpacker.lp2_string())
             black_data = unpacker.BlackListUserData()
         self.sendAnsBlackAdd(capcom_id, black_data, seq)
 
@@ -1653,7 +1653,7 @@ class PatRequestHandler(server.BasicPatHandler):
         JP: ブラックデータ削除要求
         TR: Black data deletion request
         """
-        capcom_id = pati.unpack_lp2_string(data)
+        capcom_id = to_str(pati.unpack_lp2_string(data))
         self.sendAnsBlackDelete(capcom_id, seq)
 
     def sendAnsBlackDelete(self, capcom_id, seq):
@@ -1745,7 +1745,7 @@ class PatRequestHandler(server.BasicPatHandler):
         TR: Layer specified chat transmission
         """
         with pati.Unpacker(data) as unpacker:
-            recipient_id = unpacker.lp2_string()
+            recipient_id = to_str(unpacker.lp2_string())
             info = unpacker.MessageInfo()
             message = unpacker.lp2_string()
         self.server.debug("ReqTell: {}, {!r}, {}".format(
@@ -2189,7 +2189,7 @@ class PatRequestHandler(server.BasicPatHandler):
         """
         with pati.Unpacker(data) as unpacker:
             unk1, = unpacker.struct(">B")
-            capcom_id = unpacker.lp2_string()
+            capcom_id = to_str(unpacker.lp2_string())
             offset, length = unpacker.struct(">II")
         self.sendAnsUserBinaryNotice(unk1, capcom_id, offset, length, seq)
 

--- a/mh/pat.py
+++ b/mh/pat.py
@@ -1827,7 +1827,7 @@ class PatRequestHandler(server.BasicPatHandler):
         TR: Send partner message
         """
         with pati.Unpacker(data) as unpacker:
-            recipient_id = unpacker.lp2_string()
+            recipient_id = to_str(unpacker.lp2_string())
             info = unpacker.MessageInfo()
             message = unpacker.lp2_string()
         self.server.debug("ReqTell: {}, {!r}, {}".format(
@@ -1854,9 +1854,11 @@ class PatRequestHandler(server.BasicPatHandler):
         data = b""
         data += pati.lp2_string(recipient_id)
         info.unk_long_0x02 = pati.Long(20)
+        info.sender_id = pati.String(self.session.capcom_id)
+        info.sender_name = pati.String(self.session.hunter_name)
         data += info.pack()
         data += pati.lp2_string(message)
-        self.send_packet(PatID4.NtcTell, data, seq)
+        self.try_send_packet_to(recipient_id, PatID4.NtcTell, data, seq)
 
     def recvReqFriendAdd(self, packet_id, data, seq):
         """ReqFriendAdd packet.

--- a/mh/session.py
+++ b/mh/session.py
@@ -241,10 +241,19 @@ class Session(object):
         start = first_index - 1
         return players[start:start+count]
 
+    def find_user_by_capcom_id(self, capcom_id):
+        sessions = DB.find_users(capcom_id=capcom_id)
+        if sessions:
+            return sessions[0]
+        return None
+
     def find_users(self, capcom_id, hunter_name, first_index, count):
         users = DB.find_users(capcom_id, hunter_name)
         start = first_index - 1
         return users[start:start+count]
+
+    def get_user_name(self, capcom_id):
+        return DB.get_user_name(capcom_id)
 
     def leave_server(self):
         DB.leave_server(self, self.local_info["server_id"])
@@ -384,3 +393,15 @@ class Session(object):
                 (1, (weapon_type << 24) | location),
                 (2, hunter_rank << 16)
         ]
+
+    def add_friend_request(self, capcom_id):
+        return DB.add_friend_request(self.capcom_id, capcom_id)
+
+    def accept_friend(self, capcom_id, accepted=True):
+        return DB.accept_friend(self.capcom_id, capcom_id, accepted)
+
+    def delete_friend(self, capcom_id):
+        return DB.delete_friend(self.capcom_id, capcom_id)
+
+    def get_friends(self, first_index=None, count=None):
+        return DB.get_friends(self.capcom_id, first_index, count)


### PR DESCRIPTION
This PR implements properly packets related to messages and friend lists. AFAICT, a stable index doesn't seem necessary as the friend list isn't shared with other players nor is involved in some kind of negotiation like city's host, quest slots, etc.

Tested on Python2/3 and on both the Japanese and US version of the game.

Ready to be reviewed, tested & merged.