### PR TITLE
Start server worker thread when expecting work not before

### DIFF
--- a/mh/server.py
+++ b/mh/server.py
@@ -170,7 +170,6 @@ class BasicPatServer(object):
             )
             self.worker_queues.append(thread_queue)
             self.worker_threads.append(thread)
-            thread.start()
 
         if bind_and_activate:
             try:
@@ -198,6 +197,9 @@ class BasicPatServer(object):
     def serve_forever(self):
         self.__is_shut_down.clear()
         try:
+            for thread in self.worker_threads:
+                thread.start()
+
             with self.selector as selector:
                 selector.register(self, selectors.EVENT_READ)
 


### PR DESCRIPTION
Currently on `dev` if we try to run the server with Python v3 without `LegacySSL=ON` we would hit hit this error:
![image](https://github.com/sepalani/MH3SP/assets/2200611/4fd3a316-5922-4c82-9d81-eef867c5552d)
Which would crash the main thread, the issue is that the Python VM would not terminate the process instead it would wait for all the threads to be _joined_. This is problematic because the worker threads are expecting work to be done because they are started in the constructor of the server class. This in turn make the process unkillable by means of CTRL+C

Now we defer starting the worker threads until we actually start serving the server.