### PR TITLE
Remove LegacySSL option and automatically pick the appropriate config

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,7 +1,6 @@
 [SSL]
 DefaultCert = cert/server.crt
 DefaultKey = cert/server.key
-LegacySSL = OFF
 
 [OPN]
 IP = 0.0.0.0


### PR DESCRIPTION
This PR removes the `LegacySSL` option and picks automatically the appropriate SSL config.

Ready to be reviewed & tested.