### PR TITLE
Patched OPN server to fix the SSL stall issue

### DIFF
--- a/opn_server.py
+++ b/opn_server.py
@@ -6,17 +6,27 @@
 
 from mh.pat import PatServer, PatRequestHandler
 
-from other.utils import server_base, server_main
+from other.utils import server_base, server_main, wii_ssl_wrap_socket
 
 
 class OpnServer(PatServer):
     """Basic OPN server class."""
-    pass
+    def __init__(self, address, handler_class,
+                max_thread_count=0, logger=None, debug_mode=False,
+                ssl_cert=None, ssl_key=None):
+        super(OpnServer, self).__init__(address, handler_class, 
+                max_thread_count=max_thread_count,
+                logger=logger, debug_mode=debug_mode)
+        self.ssl_cert = ssl_cert
+        self.ssl_key = ssl_key
 
 
 class OpnRequestHandler(PatRequestHandler):
     """Basic OPN server request handler class."""
-    pass
+    def __init__(self, socket, client_address, server):
+        if server.ssl_cert is not None and server.ssl_key is not None:
+            socket = wii_ssl_wrap_socket(socket, server.ssl_cert, server.ssl_key)
+        super(OpnRequestHandler, self).__init__(socket, client_address, server)
 
 
 BASE = server_base("OPN", OpnServer, OpnRequestHandler)

--- a/other/utils.py
+++ b/other/utils.py
@@ -340,7 +340,7 @@ def wii_ssl_wrap_socket(sock, ssl_cert, ssl_key):
     return context.wrap_socket(sock, server_side=True)
 
 
-def create_server(server_class, server_handler,
+def create_server(server_class, server_handler, 
                   address="0.0.0.0", port=8200, name="Server", max_thread=0,
                   use_ssl=True, ssl_cert="server.crt", ssl_key="server.key",
                   log_to_file=True, log_filename="server.log",
@@ -351,11 +351,14 @@ def create_server(server_class, server_handler,
         log_to_file=log_filename if log_to_file else "",
         log_to_console=log_to_console,
         log_to_window=log_to_window)
-    server = server_class((address, port), server_handler, max_thread, logger,
-                          debug_mode)
 
     if use_ssl:
-        server.socket = wii_ssl_wrap_socket(server.socket, ssl_cert, ssl_key)
+        server = server_class((address, port), server_handler,
+                          max_thread, logger, debug_mode,
+                          ssl_cert=ssl_cert, ssl_key=ssl_key)
+    else:
+        server = server_class((address, port), server_handler,
+                          max_thread, logger, debug_mode)
 
     return server
 


### PR DESCRIPTION
This patch should fix the issue with the login server/OPN server going down at random periods. The issue was caused by foreign connections being established to the OPN server's port and then no data being transmitted, resulting in an eternal "SSL stall" while the server waits for the handshake to be completed. This blocked any further incoming connections.