### PR TITLE
Backport some database and FMP state changes

### DIFF
--- a/fmp_server.py
+++ b/fmp_server.py
@@ -9,17 +9,28 @@ import struct
 import mh.pat_item as pati
 from mh.constants import PatID4
 from mh.pat import PatRequestHandler, PatServer
+from mh.session import FMPSession
+from mh.state import State
 from other.utils import hexdump, server_base, server_main, to_str
 
 
 class FmpServer(PatServer):
     """Basic FMP server class."""
     # TODO: Backport close cache logic
-    pass
+    def __init__(self, *args, **kwargs):
+        PatServer.__init__(self, *args, **kwargs)
+        self.fmp_state = State()
+        # TODO: Backport the cache server registration logic instead
+        import mh.database as db
+        db.get_instance().servers = self.fmp_state.servers
 
 
 class FmpRequestHandler(PatRequestHandler):
     """Basic FMP server request handler class."""
+
+    def on_init(self):
+        PatRequestHandler.on_init(self)
+        self.session = FMPSession(self.session)
 
     def recvAnsConnection(self, packet_id, data, seq):
         """AnsConnection packet."""

--- a/mh/database.py
+++ b/mh/database.py
@@ -7,9 +7,8 @@
 import inspect
 import random
 import sqlite3
-import time
 from other import utils
-from threading import RLock, local as thread_local
+from threading import local as thread_local
 
 
 CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -23,357 +22,9 @@ MEDIA_VERSIONS = {
 
 BLANK_CAPCOM_ID = "******"
 
-RESERVE_DC_TIMEOUT = 40.0
-
 
 def new_random_str(length=6):
     return "".join(random.choice(CHARSET) for _ in range(length))
-
-
-class ServerType(object):
-    OPEN = 1
-    ROOKIE = 2
-    EXPERT = 3
-    RECRUITING = 4
-
-
-class LayerState(object):
-    EMPTY = 1
-    FULL = 2
-    JOINABLE = 3
-
-
-class Lockable(object):
-    def __init__(self):
-        self._lock = RLock()
-
-    def lock(self):
-        return self
-
-    def __enter__(self):
-        # Returns True if lock was acquired, False otherwise
-        return self._lock.acquire()
-
-    def __exit__(self, *args):
-        self._lock.release()
-
-
-class Players(Lockable):
-    def __init__(self, capacity):
-        assert capacity > 0, "Collection capacity can't be zero"
-
-        self.slots = [None for _ in range(capacity)]
-        self.used = 0
-        super(Players, self).__init__()
-
-    def get_used_count(self):
-        return self.used
-
-    def get_capacity(self):
-        return len(self.slots)
-
-    def add(self, item):
-        with self.lock():
-            if self.used >= len(self.slots):
-                return -1
-
-            item_index = self.index(item)
-            if item_index != -1:
-                return item_index
-
-            for i, v in enumerate(self.slots):
-                if v is not None:
-                    continue
-
-                self.slots[i] = item
-                self.used += 1
-                return i
-
-            return -1
-
-    def remove(self, item):
-        assert item is not None, "Item != None"
-
-        with self.lock():
-            if self.used < 1:
-                return False
-
-            if isinstance(item, int):
-                if item >= self.get_capacity():
-                    return False
-
-                self.slots[item] = None
-                self.used -= 1
-                return True
-
-            for i, v in enumerate(self.slots):
-                if v != item:
-                    continue
-
-                self.slots[i] = None
-                self.used -= 1
-                return True
-
-            return False
-
-    def index(self, item):
-        assert item is not None, "Item != None"
-
-        for i, v in enumerate(self.slots):
-            if v == item:
-                return i
-
-        return -1
-
-    def clear(self):
-        with self.lock():
-            for i in range(self.get_capacity()):
-                self.slots[i] = None
-
-    def find_first(self, **kwargs):
-        if self.used < 1:
-            return None
-
-        for p in self.slots:
-            if p is None:
-                continue
-
-            for k, v in kwargs.items():
-                if getattr(p, k) != v:
-                    break
-            else:
-                return p
-
-        return None
-
-    def find_by_capcom_id(self, capcom_id):
-        return self.find_first(capcom_id=capcom_id)
-
-    def __len__(self):
-        return self.used
-
-    def __iter__(self):
-        if self.used < 1:
-            return
-
-        for i, v in enumerate(self.slots):
-            if v is None:
-                continue
-
-            yield i, v
-
-
-class Circle(Lockable):
-    def __init__(self, parent):
-        # type: (City) -> None
-        self.parent = parent
-        self.leader = None
-        self.players = Players(4)
-        self.departed = False
-        self.quest_id = 0
-        self.embarked = False
-        self.password = None
-        self.remarks = None
-
-        self.unk_byte_0x0e = 0
-        super(Circle, self).__init__()
-
-    def get_population(self):
-        return len(self.players)
-
-    def get_capacity(self):
-        return self.players.get_capacity()
-
-    def is_full(self):
-        return self.get_population() == self.get_capacity()
-
-    def is_empty(self):
-        return self.leader is None
-
-    def is_joinable(self):
-        return not self.departed and not self.is_full()
-
-    def has_password(self):
-        return self.password is not None
-
-    def reset_players(self, capacity):
-        with self.lock():
-            self.players = Players(capacity)
-
-    def reset(self):
-        with self.lock():
-            self.leader = None
-            self.reset_players(4)
-            self.departed = False
-            self.quest_id = 0
-            self.embarked = False
-            self.password = None
-            self.remarks = None
-
-            self.unk_byte_0x0e = 0
-
-
-class City(Lockable):
-    LAYER_DEPTH = 3
-
-    def __init__(self, name, parent):
-        # type: (str, Gate) -> None
-        self.name = name
-        self.parent = parent
-        self.state = LayerState.EMPTY
-        self.players = Players(4)
-        self.optional_fields = []
-        self.leader = None
-        self.reserved = None
-        self.circles = [
-            # One circle per player
-            Circle(self) for _ in range(self.get_capacity())
-        ]
-        super(City, self).__init__()
-
-    def get_population(self):
-        return len(self.players)
-
-    def in_quest_players(self):
-        return sum(p.is_in_quest() for _, p in self.players)
-
-    def get_capacity(self):
-        return self.players.get_capacity()
-
-    def get_state(self):
-        if self.reserved:
-            return LayerState.FULL
-
-        size = self.get_population()
-        if size == 0:
-            return LayerState.EMPTY
-        elif size < self.get_capacity():
-            return LayerState.JOINABLE
-        else:
-            return LayerState.FULL
-
-    def get_pathname(self):
-        pathname = self.name
-        it = self.parent
-        while it is not None:
-            pathname = it.name + "\t" + pathname
-            it = it.parent
-        return pathname
-
-    def get_first_empty_circle(self):
-        with self.lock():
-            for index, circle in enumerate(self.circles):
-                if circle.is_empty():
-                    return circle, index
-        return None, None
-
-    def get_circle_for(self, leader_session):
-        with self.lock():
-            for index, circle in enumerate(self.circles):
-                if circle.leader == leader_session:
-                    return circle, index
-        return None, None
-
-    def clear_circles(self):
-        with self.lock():
-            for circle in self.circles:
-                circle.reset()
-
-    def reserve(self, reserve):
-        with self.lock():
-            if reserve:
-                self.reserved = time.time()
-            else:
-                self.reserved = None
-
-    def reset(self):
-        with self.lock():
-            self.state = LayerState.EMPTY
-            self.players.clear()
-            self.optional_fields = []
-            self.leader = None
-            self.reserved = None
-            self.clear_circles()
-
-
-class Gate(object):
-    LAYER_DEPTH = 2
-
-    def __init__(self, name, parent, city_count=40, player_capacity=100):
-        # type: (str, Server, int, int) -> None
-        self.name = name
-        self.parent = parent
-        self.state = LayerState.EMPTY
-        self.cities = [
-            City("City{}".format(i), self)
-            for i in range(1, city_count+1)
-        ]
-        self.players = Players(player_capacity)
-        self.optional_fields = []
-
-    def get_population(self):
-        return len(self.players) + sum((
-            city.get_population()
-            for city in self.cities
-        ))
-
-    def get_capacity(self):
-        return self.players.get_capacity()
-
-    def get_state(self):
-        size = self.get_population()
-        if size == 0:
-            return LayerState.EMPTY
-        elif size < self.get_capacity():
-            return LayerState.JOINABLE
-        else:
-            return LayerState.FULL
-
-
-class Server(object):
-    LAYER_DEPTH = 1
-
-    def __init__(self, name, server_type, gate_count=40, capacity=2000,
-                 addr=None, port=None):
-        self.name = name
-        self.parent = None
-        self.server_type = server_type
-        self.addr = addr  # public IP address
-        self.port = port
-        self.gates = [
-            Gate("City Gate{}".format(i), self)
-            for i in range(1, gate_count+1)
-        ]
-        self.players = Players(capacity)
-
-    def get_population(self):
-        return len(self.players) + sum((
-            gate.get_population() for gate in self.gates
-        ))
-
-    def get_capacity(self):
-        return self.players.get_capacity()
-
-
-def new_servers():
-    servers = []
-    servers.extend([
-        Server("Valor{}".format(i), ServerType.OPEN)
-        for i in range(1, 5)
-    ])
-    servers.extend([
-        Server("Beginners{}".format(i), ServerType.ROOKIE)
-        for i in range(1, 3)
-    ])
-    servers.extend([
-        Server("Veterans{}".format(i), ServerType.EXPERT)
-        for i in range(1, 3)
-    ])
-    servers.extend([
-        Server("Greed{}".format(i), ServerType.RECRUITING)
-        for i in range(1, 5)
-    ])
-    return servers
 
 
 class TempDatabase(object):
@@ -403,7 +54,6 @@ class TempDatabase(object):
             # Capcom ID => List of Capcom IDs
             # TODO: May need stable index, see Players class
         }
-        self.servers = new_servers()
 
     def get_support_code(self, session):
         """Get the online support code or create one."""
@@ -500,93 +150,8 @@ class TempDatabase(object):
             ])
         return capcom_ids
 
-    def join_server(self, session, index):
-        if session.local_info["server_id"] is not None:
-            self.leave_server(session, session.local_info["server_id"])
-        server = self.get_server(index)
-        server.players.add(session)
-        session.local_info["server_id"] = index
-        session.local_info["server_name"] = server.name
-        return server
-
-    def leave_server(self, session, index):
-        self.get_server(index).players.remove(session)
-        session.local_info["server_id"] = None
-        session.local_info["server_name"] = None
-
-    def get_server_time(self):
-        pass
-
-    def get_game_time(self):
-        pass
-
-    def get_servers(self):
-        return self.servers
-
-    def get_server(self, index):
-        assert 0 < index <= len(self.servers), "Invalid server index"
-        return self.servers[index - 1]
-
-    def get_gates(self, server_id):
-        return self.get_server(server_id).gates
-
-    def get_gate(self, server_id, index):
-        gates = self.get_gates(server_id)
-        assert 0 < index <= len(gates), "Invalid gate index"
-        return gates[index - 1]
-
-    def join_gate(self, session, server_id, index):
-        gate = self.get_gate(server_id, index)
-        gate.parent.players.remove(session)
-        gate.players.add(session)
-        session.local_info["gate_id"] = index
-        session.local_info["gate_name"] = gate.name
-        return gate
-
-    def leave_gate(self, session):
-        gate = self.get_gate(session.local_info["server_id"],
-                             session.local_info["gate_id"])
-        gate.parent.players.add(session)
-        gate.players.remove(session)
-        session.local_info["gate_id"] = None
-        session.local_info["gate_name"] = None
-
-    def get_cities(self, server_id, gate_id):
-        return self.get_gate(server_id, gate_id).cities
-
-    def get_city(self, server_id, gate_id, index):
-        cities = self.get_cities(server_id, gate_id)
-        assert 0 < index <= len(cities), "Invalid city index"
-        return cities[index - 1]
-
-    def reserve_city(self, server_id, gate_id, index, reserve):
-        city = self.get_city(server_id, gate_id, index)
-        with city.lock():
-            reserved_time = city.reserved
-            if reserve and reserved_time and \
-               time.time()-reserved_time < RESERVE_DC_TIMEOUT:
-                return False
-            city.reserve(reserve)
-        return True
-
-    def get_all_users(self, server_id, gate_id, city_id):
-        """Search for users in layers and its children.
-
-        Let's assume wildcard search isn't possible for servers and gates.
-        A wildcard search happens when the id is zero.
-        """
-        assert 0 < server_id, "Invalid server index"
-        assert 0 < gate_id, "Invalid gate index"
-        gate = self.get_gate(server_id, gate_id)
-        users = list(gate.players)
-        cities = [
-            self.get_city(server_id, gate_id, city_id)
-        ] if city_id else self.get_cities(server_id, gate_id)
-        for city in cities:
-            users.extend(list(city.players))
-        return users
-
-    def find_users(self, capcom_id="", hunter_name=""):
+    def find_users(self, capcom_id="", hunter_name=b""):
+        # type: (str, bytes) -> list["Session"]
         assert capcom_id or hunter_name, "Search can't be empty"
         users = []
         for user_id, user_info in self.capcom_ids.items():
@@ -605,59 +170,6 @@ class TempDatabase(object):
         if capcom_id not in self.capcom_ids:
             return ""
         return self.capcom_ids[capcom_id]["name"]
-
-    def create_city(self, session, server_id, gate_id, index,
-                    settings, optional_fields):
-        city = self.get_city(server_id, gate_id, index)
-        with city.lock():
-            city.optional_fields = optional_fields
-            city.leader = session
-            city.reserved = None
-        return city
-
-    def join_city(self, session, server_id, gate_id, index):
-        city = self.get_city(server_id, gate_id, index)
-        with city.lock():
-            city.parent.players.remove(session)
-            city.players.add(session)
-            session.local_info["city_name"] = city.name
-        session.local_info["city_id"] = index
-        return city
-
-    def leave_city(self, session):
-        city = self.get_city(session.local_info["server_id"],
-                             session.local_info["gate_id"],
-                             session.local_info["city_id"])
-        with city.lock():
-            city.parent.players.add(session)
-            city.players.remove(session)
-            if not city.get_population():
-                city.reset()
-        session.local_info["city_id"] = None
-        session.local_info["city_name"] = None
-
-    def layer_detail_search(self, server_type, fields):
-        cities = []
-
-        def match_city(city, fields):
-            with city.lock():
-                return all((
-                    field in city.optional_fields
-                    for field in fields
-                ))
-
-        for server in self.servers:
-            if server.server_type != server_type:
-                continue
-            for gate in server.gates:
-                if not gate.get_population():
-                    continue
-                cities.extend([
-                    city
-                    for city in gate.cities
-                    if match_city(city, fields)
-                ])
-        return cities
 
     def add_friend_request(self, sender_id, recipient_id):
         # Friend invite can be sent to arbitrary Capcom ID
@@ -1148,14 +660,23 @@ class DebugDatabase(TempSQLiteDatabase):
 CURRENT_DB = \
     MySQLDatabase() \
     if utils.is_mysql_enabled("MYSQL") \
-    else TempSQLiteDatabase()
+    else TempSQLiteDatabase()  # type: TempDatabase
 
 
 def get_instance():
+    # type: () -> TempDatabase
+    """Return a database instance like module singleton.
+
+    TODO:
+     - Rename the TempDatabase interface to DatabaseInterface or similar
+     - Proper type hint, though any implementation must implement all the
+    interface methods.
+    """
     return CURRENT_DB
 
 
 def implementation_check(cls, base=TempDatabase):
+    # type: (type, type) -> bool
     """Debug implementation check allowing to see methods dependencies.
 
     Example:
@@ -1163,6 +684,7 @@ def implementation_check(cls, base=TempDatabase):
     >>> implementation_check(TempSQLiteDatabase)
     """
     def is_method(obj):
+        # type: (object) -> bool
         """Python3's missing unbound methods workaround."""
         if inspect.ismethod(obj):
             return True
@@ -1179,7 +701,7 @@ def implementation_check(cls, base=TempDatabase):
 
     print("class {}:".format(cls.__name__))
 
-    for name, obj in inspect.getmembers(cls, is_method):
+    for name, _ in inspect.getmembers(cls, is_method):
         if name in missing_methods:
             missing_methods.remove(name)
         for c in mros:

--- a/mh/pat.py
+++ b/mh/pat.py
@@ -19,8 +19,8 @@ from mh.constants import \
     CHARGE, VULGARITY_INFO, FMP_VERSION, PAT_BINARIES, PAT_NAMES, \
     MAINTENANCE, UNPATCHED, \
     PatID4, get_pat_binary_from_version
-from mh.session import Session
-import mh.database as db
+from mh.session import Session, FMPSession
+from mh.state_models import Server, Gate, City, Circle, Players  # noqa: F401
 
 try:
     from typing import Literal
@@ -81,7 +81,7 @@ class PatServer(server.BasicPatServer, Logger):
     # TODO: Backport broadcasting refactoring if needed
 
     def broadcast(self, players, packet_id, data, seq, to_exclude=None):
-        # type: (db.Players, int, bytes, int, Session|None) -> None
+        # type: (Players, int, bytes, int, Session|None) -> None
         handlers = []
         with players.lock():
             for _, player in players:
@@ -102,7 +102,7 @@ class PatServer(server.BasicPatServer, Logger):
 
     def circle_broadcast(self, circle, packet_id, data, seq,
                          session=None):
-        # type: (db.Circle, int, bytes, int, Session|None) -> None
+        # type: (Circle, int, bytes, int, Session|None) -> None
         with circle.lock():
             self.broadcast(circle.players, packet_id, data, seq, session)
 
@@ -302,6 +302,7 @@ class PatRequestHandler(server.BasicPatHandler):
 
         has_ban = "online_support_code" in settings and \
             pat_ticket in BANNED_ONLINE_SUPPORT_CODES
+        # Used by OPN server, not sure we should rely on session at this point
         if has_ban or len(self.session.get_servers()) == 0:
             self.sendNtcLogin(2, settings, seq)
         else:
@@ -932,6 +933,8 @@ class PatRequestHandler(server.BasicPatHandler):
         JP: FMPリストバージョン確認
         TR: FMP list version check
 
+        NB: This packet is also used by the LMP server.
+
         TODO:
          - Find why there are 2 versions of FMP packets.
          - Find why most of the 2 versions are ignored.
@@ -967,6 +970,8 @@ class PatRequestHandler(server.BasicPatHandler):
         ID: 61310100 / 63110100
         JP: FMPリスト数送信 / FMPリスト数要求
         TR: Send FMP list count / FMP list count request
+
+        NB: This packet is also used by the LMP server.
         """
         # TODO: Might be worth investigating these parameters as
         # they might be useful when using multiple FMP servers.
@@ -987,6 +992,8 @@ class PatRequestHandler(server.BasicPatHandler):
         ID: 61310200
         JP: FMPリスト数応答
         TR: FMP list count response
+
+        NB: This packet is also used by the LMP server.
         """
         unused = 0
         count = len(self.session.get_servers())
@@ -1013,6 +1020,8 @@ class PatRequestHandler(server.BasicPatHandler):
         ID: 61320100 / 63120100
         JP: FMPリスト送信 / FMPリスト要求
         TR: Send FMP list / FMP list response
+
+        NB: This packet is also used by the LMP server.
         """
         first_index, count = struct.unpack_from(">II", data)
         if packet_id == PatID4.ReqFmpListData:
@@ -1058,6 +1067,8 @@ class PatRequestHandler(server.BasicPatHandler):
         ID: 61330100 / 63130100
         JP: FMPリスト送信終了 / FMPリスト終了送信
         TR: FMP list end of transmission / FMP list transmission end
+
+        NB: This packet is also used by the LMP server.
         """
         if packet_id == PatID4.ReqFmpListFoot:
             self.sendAnsFmpListFoot(seq)
@@ -1132,21 +1143,26 @@ class PatRequestHandler(server.BasicPatHandler):
         TR: FMP data request
 
         TODO: Do not hardcode the data and find the meaning of all fields.
+
+        NB: This packet is also used by the LMP server.
         """
         index, = struct.unpack_from(">I", data)
         fields = pati.unpack_bytes(data, 4)
-        server = self.session.join_server(index)
+        # FIXME: Doesn't seem to make sense here,
+        # e.g. on LMP server, as "FmpInfo" packet
+        # server = self.session.join_server(index)
         config = get_config("FMP")
         fmp_addr = get_external_ip(config)
         fmp_port = config["Port"]
         fmp_data = pati.FmpData()
-        fmp_data.server_address = pati.String(server.addr or fmp_addr)
-        fmp_data.server_port = pati.Word(server.port or fmp_port)
+        fmp_data.server_address = pati.String(fmp_addr)
+        fmp_data.server_port = pati.Word(fmp_port)
         fmp_data.assert_fields(fields)
         # TODO: Backport central logic
-        if packet_id == PatID4.ReqFmpInfo:
+        if packet_id == PatID4.ReqFmpInfo:  # LMP version
             self.sendAnsFmpInfo(fmp_data, fields, seq)
-        elif packet_id == PatID4.ReqFmpInfo2:
+        elif packet_id == PatID4.ReqFmpInfo2:  # FMP version
+            self.session.join_server(index)
             self.sendAnsFmpInfo2(fmp_data, fields, seq)
 
         # Preserve session in database, due to server selection
@@ -1416,8 +1432,9 @@ class PatRequestHandler(server.BasicPatHandler):
         JP: レイヤ開始要求
         TR: Layer start request
         """
-        unk1 = pati.unpack_bytes(data)
-        unk2 = pati.unpack_bytes(data, len(unk1) + 1)
+        with pati.Unpacker(data) as unpacker:
+            unk1 = unpacker.bytes()
+            unk2 = unpacker.bytes()
         self.sendAnsLayerStart(unk1, unk2, seq)
 
     def sendAnsLayerStart(self, unk1, unk2, seq):
@@ -2402,7 +2419,17 @@ class PatRequestHandler(server.BasicPatHandler):
         for i, city in enumerate(cities):
             with city.lock():
                 layer_data = pati.LayerData.create_from(i, city)
-                layer_data.assert_fields(self.search_info["layer_fields"])
+                layer_fields = self.search_info["layer_fields"]
+                filtered_fields = layer_data.filter_fields(layer_fields)  # noqa: F841
+                """
+                # During testing / TODO: Investigate
+                filtered_fields = [
+                    (5, 'index', Word(0))
+                    (17, 'positionInterval', Long(500))
+                    (18, 'unk_byte_0x12', Byte(1))
+                ]
+                """
+                layer_data.assert_fields(layer_fields)
                 data += layer_data.pack()
                 data += pati.pack_optional_fields(city.optional_fields)
                 with city.players.lock():
@@ -2737,7 +2764,7 @@ class PatRequestHandler(server.BasicPatHandler):
     def notify_city_info_set(self, path):
         # type: (pati.LayerPath) -> None
         city = self.get_layer(path)
-        assert isinstance(city, db.City)
+        assert isinstance(city, City)
 
         gate = city.parent
         layer_data = pati.LayerData.create_from(path.city_id, city, path)
@@ -2749,7 +2776,7 @@ class PatRequestHandler(server.BasicPatHandler):
     def notify_city_number_set(self, path):
         # type: (pati.LayerPath) -> None
         city = self.get_layer(path)
-        assert isinstance(city, db.City)
+        assert isinstance(city, City)
 
         gate = city.parent
         layer_data = pati.LayerData.create_from(path.city_id, city, path)
@@ -2757,17 +2784,16 @@ class PatRequestHandler(server.BasicPatHandler):
         self.server.broadcast(gate.players, PatID4.NtcLayerUserNum,
                               number_set, 0, self.session)
 
-    @staticmethod
-    def get_layer(path):
-        # type: (pati.LayerPath) -> db.Server | db.Gate | db.City | None
-        database = db.get_instance()
+    def get_layer(self, path):
+        # type: (pati.LayerPath) -> Server | Gate | City | None
+        fmp_state = self.session.FMP()
         if path.city_id > 0:
-            return database.get_city(path.server_id, path.gate_id,
-                                     path.city_id)
+            return fmp_state.get_city(path.server_id, path.gate_id,
+                                      path.city_id)
         elif path.gate_id > 0:
-            return database.get_gate(path.server_id, path.gate_id)
+            return fmp_state.get_gate(path.server_id, path.gate_id)
         elif path.server_id > 0:
-            return database.get_server(path.server_id)
+            return fmp_state.get_server(path.server_id)
         return None
 
     def notify_layer_departure(self, end):
@@ -2793,7 +2819,7 @@ class PatRequestHandler(server.BasicPatHandler):
 
         if path.city_id > 0:
             city = self.get_layer(path)
-            assert isinstance(city, db.City)
+            assert isinstance(city, City)
 
             self.notify_city_number_set(path)
             if city.leader is None:
@@ -2822,7 +2848,8 @@ class PatRequestHandler(server.BasicPatHandler):
         self.send_error("{}: {}".format(type(e).__name__, str(e)))
 
     def on_finish(self):
-        self.notify_layer_departure(True)
+        if isinstance(self.session, FMPSession):
+            self.notify_layer_departure(True)
         # TODO: Backport session_layer_end
         self.session.disconnect()
         self.session.delete()

--- a/mh/pat_item.py
+++ b/mh/pat_item.py
@@ -7,10 +7,11 @@
 import struct
 
 from collections import OrderedDict
+
 from mh.constants import pad
+from mh.state_models import Server, Gate, City
 from other.utils import to_bytearray, get_config, get_external_ip, \
     GenericUnpacker
-from mh.database import Server, Gate, City
 
 
 class ItemType:
@@ -354,6 +355,8 @@ def unpack_bytes(data, offset=0):
 
 
 class PatData(OrderedDict):
+    # TODO: type hint the whole module and add OrderedDict generic stub
+    # see https://mypy.readthedocs.io/en/stable/runtime_troubles.html
     """Pat structure holding items."""
     FIELDS = (
         (1, "field_0x01"),
@@ -363,9 +366,11 @@ class PatData(OrderedDict):
     )
 
     def __len__(self):
+        # type: () -> int
         return len(self.pack())
 
     def __repr__(self):
+        # type: () -> str
         items = [
             (index, value)
             for index, value in self.items()
@@ -380,6 +385,7 @@ class PatData(OrderedDict):
         )
 
     def __getattr__(self, name):
+        # type: (str) -> Item
         for field_id, field_name in self.FIELDS:
             if name == field_name:
                 if field_id not in self:
@@ -388,6 +394,7 @@ class PatData(OrderedDict):
         raise AttributeError("Unknown field: {}".format(name))
 
     def __setattr__(self, name, value):
+        # type: (str, Item) -> None
         for field_id, field_name in self.FIELDS:
             if name == field_name:
                 if not isinstance(value, Item):
@@ -399,6 +406,7 @@ class PatData(OrderedDict):
         raise AttributeError("Cannot set unknown field: {}".format(name))
 
     def __delattr__(self, name):
+        # type: (str) -> None
         for field_id, field_name in self.FIELDS:
             if name == field_name:
                 del self[field_id]
@@ -406,13 +414,19 @@ class PatData(OrderedDict):
         return OrderedDict.__delattr__(self, name)
 
     def __setitem__(self, key, value):
+        # type: (int, Item) -> None
         if not isinstance(key, int) or not (0 <= key <= 255):
             raise IndexError("index must be a valid numeric value")
         elif not isinstance(value, Item):
             raise ValueError("{!r} not a valid PAT item".format(value))
         return OrderedDict.__setitem__(self, key, value)
 
+    def __getitem__(self, key):
+        # type: (int) -> Item
+        return OrderedDict.__getitem__(self, key)
+
     def __contains__(self, key):
+        # type: (int | str | object) -> bool
         if isinstance(key, str):
             for field_id, field_name in self.FIELDS:
                 if field_name == key:
@@ -426,13 +440,19 @@ class PatData(OrderedDict):
 
         return OrderedDict.__contains__(self, key)
 
+    def items(self):
+        # type: () -> list[tuple[int, Item]]
+        return OrderedDict.items(self)
+
     def field_name(self, index):
+        # type: (int) -> str
         for field_id, field_name in self.FIELDS:
             if index == field_id:
                 return field_name
         return "field_0x{:02x}".format(index)
 
     def pack(self):
+        # type: () -> bytes
         """Pack PAT items."""
         items = [
             (index, value)
@@ -445,6 +465,7 @@ class PatData(OrderedDict):
         )
 
     def pack_fields(self, fields):
+        # type: (set[int]) -> bytes
         """Pack PAT items specified fields."""
         items = [
             (index, value)
@@ -458,6 +479,7 @@ class PatData(OrderedDict):
 
     @classmethod
     def unpack(cls, data, offset=0):
+        # type: (type[PatData], bytes, int) -> PatData
         obj = cls()
         field_count, = struct.unpack_from(">B", data, offset)
         offset += 1
@@ -489,10 +511,35 @@ class PatData(OrderedDict):
         return obj
 
     def assert_fields(self, fields):
-        items = set(self.keys())
+        # type: (set[int]) -> None
+        items = set(self.keys())  # type: set[int]
         fields = set(fields)
         message = "Fields mismatch: {}\n -> Expected: {}".format(items, fields)
         assert items == fields, message
+
+    def filter_fields(self, fields):
+        # type: (set[int]) -> list[tuple[int, str, Item]]
+        """Filter PatData excess of information.
+
+        Places using this method should be investigated to make sure there is
+        no oversight (or more reverse engineering needed) regarding the
+        data structure and packet used.
+        """
+        items = set(self.keys())  # type: set[int]
+        fields = set(fields)
+        missing_fields = fields - items
+        message = "Can't filter missing fields: {}\n".format(", ".join(
+            self.field_name(field_id) for field_id in missing_fields
+        ))
+        assert not missing_fields, message
+        new_fields = items - fields
+        filtered_fields = []  # type: list[tuple[int, str, Item]]
+        for field_id in new_fields:
+            filtered_fields.append(
+                (field_id, self.field_name(field_id), self[field_id])
+            )
+            del self[field_id]
+        return filtered_fields
 
 
 class DummyData(PatData):
@@ -586,6 +633,10 @@ class UserSearchInfo(PatData):
         (0x0f, "info_mine_0x0f"),
         (0x10, "info_mine_0x10"),
     )
+
+
+# FIXME: Both LayerPath and LayerData introduce a strong dependency on
+# mh.state_models, which should be avoided for this module.
 
 
 class LayerPath(object):

--- a/mh/session.py
+++ b/mh/session.py
@@ -9,6 +9,28 @@ import mh.pat_item as pati
 
 from other.utils import to_bytearray, to_str
 
+try:
+    from typing import Any, TypedDict, TYPE_CHECKING  # noqa: F401
+
+    if TYPE_CHECKING:
+        from mh.state import State  # noqa: F401
+
+    SessionLocalInfo = TypedDict(
+        "SessionLocalInfo", {
+            "server_id": None | int,
+            "server_name": None | str,  # maybe bytes to support accents?
+            "gate_id": None | int,
+            "gate_name": None | str,  # ditto regarding special characters
+            "city_id": None | int,
+            "city_name": None | str,  # ditto regarding special characters
+            "city_size": int,
+            "city_capacity": int,
+            "circle_id": None | int,
+        }
+    )
+except (ImportError, TypeError):
+    pass
+
 DB = db.get_instance()
 
 
@@ -25,6 +47,9 @@ class SessionState:
 class Session(object):
     """Server session class.
 
+    The goal of this class is to help writing the PAT packet logic by
+    handling complex interactions between servers/database behind the scene.
+
     TODO:
      - Finish the implementation
     """
@@ -40,7 +65,7 @@ class Session(object):
             "city_size": 0,
             "city_capacity": 0,
             "circle_id": None,
-        }
+        }  # type: SessionLocalInfo
         self.connection = connection_handler
         self.online_support_code = None
         self.request_reconnection = False
@@ -52,8 +77,81 @@ class Session(object):
         self.state = SessionState.UNKNOWN
         self.binary_setting = b""
         self.search_payload = None
-        # TODO: Backport the server_id and serialisation logic
+        # TODO: Backport the server_id logic
         self.hunter_info = pati.HunterSettings()
+
+    def serialize(self):
+        # type: () -> dict[str, Any]
+        return {
+            "pat_ticket": self.pat_ticket,
+            # TODO: local_info should be safe to serialize on its own as dict
+            "local_info_server_id": self.local_info["server_id"],
+            "local_info_server_name": self.local_info["server_name"],
+            "local_info_gate_id": self.local_info["gate_id"],
+            "local_info_gate_name": self.local_info["gate_name"],
+            "local_info_city_id": self.local_info["city_id"],
+            "local_info_city_name": self.local_info["city_name"],
+            "local_info_city_size": self.local_info["city_size"],
+            "local_info_city_capacity": self.local_info["city_capacity"],
+            "local_info_circle_id": self.local_info["circle_id"],
+            "online_support_code": self.online_support_code,
+            "capcom_id": self.capcom_id,
+            "hunter_name": self.hunter_name,
+            "hunter_stats": self.hunter_stats,
+            "layer": self.layer,
+            "state": self.state,
+            "binary_setting": self.binary_setting,
+            "hunter_info": to_str(self.hunter_info.pack())
+        }
+
+    @staticmethod
+    def deserialize(obj):
+        # type: (dict[str, Any]) -> Session
+        session = Session(None)
+        session.pat_ticket = \
+            str(obj["pat_ticket"]) \
+            if obj["pat_ticket"] else obj["pat_ticket"]
+        session.local_info["server_id"] = \
+            int(obj["local_info_server_id"]) \
+            if obj["local_info_server_id"] else obj["local_info_server_id"]
+        session.local_info["server_name"] = \
+            str(obj["local_info_server_name"]) \
+            if obj["local_info_server_name"] else obj["local_info_server_name"]
+        session.local_info["gate_id"] = \
+            int(obj["local_info_gate_id"]) \
+            if obj["local_info_gate_id"] else obj["local_info_gate_id"]
+        session.local_info["gate_name"] = \
+            str(obj["local_info_gate_name"]) \
+            if obj["local_info_gate_name"] else obj["local_info_gate_name"]
+        session.local_info["city_id"] = \
+            int(obj["local_info_city_id"]) \
+            if obj["local_info_city_id"] else obj["local_info_city_id"]
+        session.local_info["city_name"] = \
+            str(obj["local_info_city_name"]) \
+            if obj["local_info_city_name"] else obj["local_info_city_name"]
+        session.local_info["city_size"] = \
+            int(obj["local_info_city_size"]) \
+            if obj["local_info_city_size"] else obj["local_info_city_size"]
+        session.local_info["city_capacity"] = \
+            int(obj["local_info_city_capacity"]) \
+            if obj["local_info_city_capacity"] \
+            else obj["local_info_city_capacity"]
+        session.local_info["circle_id"] = \
+            int(obj["local_info_circle_id"]) \
+            if obj["local_info_circle_id"] else obj["local_info_circle_id"]
+        session.online_support_code =  \
+            str(obj["online_support_code"]) \
+            if obj["online_support_code"] else obj["online_support_code"]
+        session.capcom_id = str(obj["capcom_id"])
+        session.hunter_name = str(obj["hunter_name"])
+        session.hunter_stats = obj["hunter_stats"]
+        session.layer = int(obj["layer"])
+        session.state = int(obj["state"])
+        session.binary_setting = obj["binary_setting"]
+        h_settings = bytearray(obj["hunter_info"], encoding='ISO-8859-1')
+        session.hunter_info = pati.HunterSettings().unpack(h_settings,
+                                                           len(h_settings))
+        return session
 
     def get(self, connection_data):
         """Return the session associated with the connection data, if any."""
@@ -68,6 +166,7 @@ class Session(object):
             )
         session = DB.get_session(self.pat_ticket) or self
         if session != self:
+            # TODO: Use a less error-prone check
             assert session.connection is None, "Session is already in use"
             session.connection = self.connection
             self.connection = None
@@ -118,25 +217,111 @@ class Session(object):
     def use_user(self, index, name):
         DB.use_user(self, index, name)
 
+    def find_user_by_capcom_id(self, capcom_id):
+        sessions = DB.find_users(capcom_id=capcom_id)
+        if sessions:
+            return sessions[0]
+        return None
+
+    def find_users(self, capcom_id, hunter_name, first_index, count):
+        users = DB.find_users(capcom_id, hunter_name)
+        start = first_index - 1
+        return users[start:start+count]
+
+    def get_user_name(self, capcom_id):
+        return DB.get_user_name(capcom_id)
+
+    def add_friend_request(self, capcom_id):
+        return DB.add_friend_request(self.capcom_id, capcom_id)
+
+    def accept_friend(self, capcom_id, accepted=True):
+        return DB.accept_friend(self.capcom_id, capcom_id, accepted)
+
+    def delete_friend(self, capcom_id):
+        return DB.delete_friend(self.capcom_id, capcom_id)
+
+    def get_friends(self, first_index=None, count=None):
+        return DB.get_friends(self.capcom_id, first_index, count)
+
     # TODO: server_index and recall logic
 
     def get_servers(self):
-        return DB.get_servers()
+        """LMP servers can request the server list"""
+        return DB.servers  # FIXME: See FmpServer constructor
+
+
+class FMPSession(Session):
+    """Specialized session wrapper for FMP server.
+
+    Most methods should be unrelated to DB.
+    This prevent other servers to trigger FMP related features.
+    """
+    def __init__(self, session):
+        # type: (Session) -> None
+        self._session = session
+        self._fmp_state = session.connection.server.fmp_state  # type: State
+
+    def __getattr__(self, name):
+        # type: (str) -> Any
+        """Called when the default attribute access fails."""
+        return getattr(self._session, name)
+
+    def __setattr__(self, name, value):
+        # type: (str, Any) -> None
+        if name.startswith("_"):
+            return object.__setattr__(self, name, value)
+        return setattr(self._session, name, value)
+
+    def __eq__(self, other):
+        # type: (Session) -> bool
+        """Avoid comparison issues when wrapping around the session.
+
+        For instance, list removal is done by equality not identity,
+        in other words, FMPSession instances can get Session instances to be
+        removed from a list.
+        """
+        if isinstance(other, FMPSession):
+            other = other._session
+        elif not isinstance(other, Session):
+            return NotImplemented
+        return self._session == other
+
+    def __ne__(self, other):
+        # type: (Session) -> bool
+        x = self.__eq__(other)
+        if x is NotImplemented:
+            return NotImplemented
+        return not x
+
+    def get(self, connection_data):
+        """Wrap existing session if needed"""
+        session = Session.get(self, connection_data)
+        if not isinstance(session, FMPSession):
+            session = FMPSession(session)
+        return session
+
+    def FMP(self):
+        # type: () -> State
+        """Wrapper that can be repurposed later for cache/error handling."""
+        return self._fmp_state
+
+    def get_servers(self):
+        return self.FMP().get_servers()
 
     def get_server(self):
         assert self.local_info['server_id'] is not None
-        return DB.get_server(self.local_info['server_id'])
+        return self.FMP().get_server(self.local_info['server_id'])
 
     def get_gate(self):
         assert self.local_info['gate_id'] is not None
-        return DB.get_gate(self.local_info['server_id'],
-                           self.local_info['gate_id'])
+        return self.FMP().get_gate(self.local_info['server_id'],
+                                   self.local_info['gate_id'])
 
     def get_city(self):
         assert self.local_info['city_id'] is not None
-        return DB.get_city(self.local_info['server_id'],
-                           self.local_info['gate_id'],
-                           self.local_info['city_id'])
+        return self.FMP().get_city(self.local_info['server_id'],
+                                   self.local_info['gate_id'],
+                                   self.local_info['city_id'])
 
     def get_circle(self):
         assert self.local_info['circle_id'] is not None
@@ -197,10 +382,10 @@ class Session(object):
             (field_id, value)
             for field_id, field_type, value in detailed_fields
         ]  # Convert detailed to simple optional fields
-        return DB.layer_detail_search(server_type, fields)
+        return self.FMP().layer_detail_search(server_type, fields)
 
     def join_server(self, server_id):
-        return DB.join_server(self, server_id)
+        return self.FMP().join_server(self, server_id)
 
     def get_layer_children(self):
         if self.layer == 0:
@@ -218,74 +403,63 @@ class Session(object):
 
     def find_users_by_layer(self, server_id, gate_id, city_id,
                             first_index, count, recursive=False):
-        if recursive:
-            players = DB.get_all_users(server_id, gate_id, city_id)
-        else:
-            layer = \
-                DB.get_city(server_id, gate_id, city_id) if city_id else \
-                DB.get_gate(server_id, gate_id) if gate_id else \
-                DB.get_server(server_id)
-            players = list(layer.players)
         start = first_index - 1
+        if recursive:
+            players = self.FMP().get_all_users(server_id, gate_id, city_id)
+            return players[start:start+count]
+
+        layer = \
+            self.FMP().get_city(server_id, gate_id, city_id) if city_id else \
+            self.FMP().get_gate(server_id, gate_id) if gate_id else \
+            self.FMP().get_server(server_id)
+        players = list(layer.players)
         return players[start:start+count]
 
-    def find_user_by_capcom_id(self, capcom_id):
-        sessions = DB.find_users(capcom_id=capcom_id)
-        if sessions:
-            return sessions[0]
-        return None
-
-    def find_users(self, capcom_id, hunter_name, first_index, count):
-        users = DB.find_users(capcom_id, hunter_name)
-        start = first_index - 1
-        return users[start:start+count]
-
-    def get_user_name(self, capcom_id):
-        return DB.get_user_name(capcom_id)
-
     def leave_server(self):
-        DB.leave_server(self, self.local_info["server_id"])
+        self.FMP().leave_server(self, self.local_info["server_id"])
 
     def get_gates(self):
-        return DB.get_gates(self.local_info["server_id"])
+        return self.FMP().get_gates(self.local_info["server_id"])
 
     def join_gate(self, gate_id):
-        DB.join_gate(self, self.local_info["server_id"], gate_id)
+        self.FMP().join_gate(self, self.local_info["server_id"], gate_id)
         self.state = SessionState.GATE
 
     def leave_gate(self):
-        DB.leave_gate(self)
+        self.FMP().leave_gate(self)
         self.state = SessionState.LOG_IN
 
     def get_cities(self):
-        return DB.get_cities(self.local_info["server_id"],
-                             self.local_info["gate_id"])
+        return self.FMP().get_cities(self.local_info["server_id"],
+                                     self.local_info["gate_id"])
 
     def is_city_empty(self, city_id):
-        return DB.get_city(self.local_info["server_id"],
-                           self.local_info["gate_id"],
-                           city_id).get_state() == db.LayerState.EMPTY
+        return self.FMP().get_city(
+            self.local_info["server_id"],
+            self.local_info["gate_id"],
+            city_id
+        ).is_empty()
 
     def reserve_city(self, city_id, reserve):
-        return DB.reserve_city(self.local_info["server_id"],
-                               self.local_info["gate_id"],
-                               city_id, reserve)
+        return self.FMP().reserve_city(self.local_info["server_id"],
+                                       self.local_info["gate_id"],
+                                       city_id, reserve)
 
     def create_city(self, city_id, settings, optional_fields):
-        return DB.create_city(self,
-                              self.local_info["server_id"],
-                              self.local_info["gate_id"],
-                              city_id, settings, optional_fields)
+        return self.FMP().create_city(
+            self, self.local_info["server_id"], self.local_info["gate_id"],
+            city_id, settings, optional_fields
+        )
 
     def join_city(self, city_id):
-        DB.join_city(self,
-                     self.local_info["server_id"],
-                     self.local_info["gate_id"],
-                     city_id)
+        self.FMP().join_city(self,
+                             self.local_info["server_id"],
+                             self.local_info["gate_id"],
+                             city_id)
         self.state = SessionState.CITY
 
     def leave_city(self):
-        DB.leave_city(self)
+        self.FMP().leave_city(self)
         self.state = SessionState.GATE
 
     def try_transfer_city_leadership(self):
@@ -386,15 +560,3 @@ class Session(object):
                 (1, (weapon_type << 24) | location),
                 (2, hunter_rank << 16)
         ]
-
-    def add_friend_request(self, capcom_id):
-        return DB.add_friend_request(self.capcom_id, capcom_id)
-
-    def accept_friend(self, capcom_id, accepted=True):
-        return DB.accept_friend(self.capcom_id, capcom_id, accepted)
-
-    def delete_friend(self, capcom_id):
-        return DB.delete_friend(self.capcom_id, capcom_id)
-
-    def get_friends(self, first_index=None, count=None):
-        return DB.get_friends(self.capcom_id, first_index, count)

--- a/mh/state.py
+++ b/mh/state.py
@@ -1,0 +1,280 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# SPDX-FileCopyrightText: Copyright (C) 2023-2025 MH3SP Server Project
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""FMP server state module.
+
+Each FMP server needs to know the in-game resources it manages:
+ - Servers
+ - Gates
+ - Cities
+ - Sessions (i.e. active server connections)
+
+TODO/FIXME:
+Our current design isn't very scalable.
+"""
+
+
+from mh.database import get_instance as get_db
+from mh.state_models import Server, ServerType
+
+try:
+    from typing import TypedDict, TYPE_CHECKING
+    if TYPE_CHECKING:
+        from mh.session import Session
+        from mh.state_models import Gate, City  # noqa: F401
+
+        CapcomIDsInfo = TypedDict("CapcomIDsInfo", {
+            "name": bytes,
+            "session": None | Session
+        })
+except (ImportError, TypeError):
+    pass
+
+
+def new_servers():
+    # type: () -> list[Server]
+    # TODO: This logic was removed upstream to use harcoded values...
+    servers = []  # type: list[Server]
+    servers.extend([
+        Server("Valor{}".format(i), ServerType.OPEN)
+        for i in range(1, 5)
+    ])
+    servers.extend([
+        Server("Beginners{}".format(i), ServerType.ROOKIE)
+        for i in range(1, 3)
+    ])
+    servers.extend([
+        Server("Veterans{}".format(i), ServerType.EXPERT)
+        for i in range(1, 3)
+    ])
+    servers.extend([
+        Server("Greed{}".format(i), ServerType.RECRUITING)
+        for i in range(1, 5)
+    ])
+    return servers
+
+
+class State(object):
+    """FMP server state class.
+
+    Holds the required information not to bother too frequently:
+     - the database server
+     - the central server
+
+    Ideally, this should allow the server to be resilient and operate even
+    with limited connectivity to the database and central server.
+
+    TODO: (backport)
+     - Backport cache/server_id logic
+     - Like the following methods if needed:
+     setup_server
+     register_pat_ticket
+     get_session
+     disconnect_session
+     delete_session (+ cache logic)
+     fetch_id
+     get_servers_version
+     update_players
+     update_capcom_id
+     session_ready
+     set_session_ready
+     close_cache
+
+    FIXME: (backport)
+     - These methods should belong to db (imho)
+    new_pat_ticket -> db.generate_pat_ticket + fill self.session
+    use_capcom_id
+    use_user
+    get_users (i.e. LMP server)
+    """
+    def __init__(self):
+        self.servers = new_servers()
+        # TODO: Backport Sessions/Capcom ID handling (currently unused)
+        self.sessions = {
+            # PAT Ticket => Owner's session
+        }  # type: dict[str, Session]
+        self.capcom_ids = {
+            # Capcom ID => Owner's name and session
+            # NB: Not to be mistaken with database.capcom_ids!
+        }  # type: dict[str, CapcomIDsInfo]
+
+    def join_server(self, session, index):
+        # type: (Session, int) -> Server
+        if session.local_info["server_id"] is not None:
+            self.leave_server(session, session.local_info["server_id"])
+        # TODO: Backport cache/joining another external server
+        # It might imply moving from (array) index to (dict) server_id
+        server = self.get_server(index)
+        server.players.add(session)
+        session.local_info["server_id"] = index
+        session.local_info["server_name"] = server.name
+        return server
+
+    def leave_server(self, session, index):
+        # type: (Session, int) -> None
+        self.get_server(index).players.remove(session)
+        session.local_info["server_id"] = None
+        session.local_info["server_name"] = None
+
+    def get_server_time(self):
+        # TODO: Use it at some point or remove it
+        pass
+
+    def get_game_time(self):
+        # TODO: Use it at some point or remove it
+        pass
+
+    def get_servers(self):
+        # type: () -> list[Server]
+        # TODO: Backport cache code
+        return self.servers
+
+    def get_server(self, index):
+        # type: (int) -> Server
+        # TODO: Backport cache code
+        assert 0 < index <= len(self.servers), "Invalid server index"
+        return self.servers[index - 1]
+
+    def get_gates(self, server_id):
+        # type: (int) -> list[Gate]
+        return self.get_server(server_id).gates
+
+    def get_gate(self, server_id, index):
+        # type: (int, int) -> Gate
+        gates = self.get_gates(server_id)
+        assert 0 < index <= len(gates), "Invalid gate index"
+        return gates[index - 1]
+
+    def join_gate(self, session, server_id, index):
+        # type: (Session, int, int) -> Gate
+        gate = self.get_gate(server_id, index)
+        gate.parent.players.remove(session)
+        gate.players.add(session)
+        session.local_info["gate_id"] = index
+        session.local_info["gate_name"] = gate.name
+        return gate
+
+    def leave_gate(self, session):
+        # type: (Session) -> None
+        gate = self.get_gate(session.local_info["server_id"],
+                             session.local_info["gate_id"])
+        gate.parent.players.add(session)
+        gate.players.remove(session)
+        session.local_info["gate_id"] = None
+        session.local_info["gate_name"] = None
+
+    def get_cities(self, server_id, gate_id):
+        # type: (int, int) -> list[City]
+        return self.get_gate(server_id, gate_id).cities
+
+    def get_city(self, server_id, gate_id, index):
+        # type: (int, int, int) -> City
+        cities = self.get_cities(server_id, gate_id)
+        assert 0 < index <= len(cities), "Invalid city index"
+        return cities[index - 1]
+
+    def reserve_city(self, server_id, gate_id, index, reserve):
+        # type: (int, int, int, bool) -> bool
+        city = self.get_city(server_id, gate_id, index)
+        with city.lock():
+            if reserve and city.is_reserved():
+                return False
+            city.reserve(reserve)
+        return True
+
+    def get_all_users(self, server_id, gate_id, city_id):
+        # type: (int, int, None | int) -> list[tuple[int, Session]]
+        """Search for users in layers and its children.
+
+        Let's assume wildcard search isn't possible for servers and gates.
+        A wildcard search happens when the id is zero.
+        """
+        assert 0 < server_id, "Invalid server index"
+        assert 0 < gate_id, "Invalid gate index"
+        gate = self.get_gate(server_id, gate_id)
+        users = list(gate.players)
+        cities = [
+            self.get_city(server_id, gate_id, city_id)
+        ] if city_id else self.get_cities(server_id, gate_id)
+        for city in cities:
+            users.extend(list(city.players))
+        return users
+
+    def find_users(self, capcom_id="", hunter_name=b""):
+        # type: (str, bytes) -> list[Session]
+        assert capcom_id or hunter_name, "Search can't be empty"
+        users = []  # type: list[Session]
+        for user_id, user_info in self.capcom_ids.items():
+            session = user_info["session"]
+            if not session:
+                continue
+            if capcom_id and capcom_id not in user_id:
+                continue
+            if hunter_name and \
+                    hunter_name.lower() not in user_info["name"].lower():
+                continue
+            users.append(session)
+        # TODO: Backport cache/central code
+        # FIXME: We need to rely on DB meanwhile...
+        assert len(users) == 0, "State doesn't save IDs/Session yet"
+        users.extend(get_db().find_users(
+            capcom_id=capcom_id,
+            hunter_name=hunter_name
+        ))
+        return users
+
+    def create_city(self, session, server_id, gate_id, index,
+                    settings, optional_fields):
+        city = self.get_city(server_id, gate_id, index)
+        with city.lock():
+            city.optional_fields = optional_fields
+            city.leader = session
+        return city
+
+    def join_city(self, session, server_id, gate_id, index):
+        # type: (Session, int, int, int) -> City
+        city = self.get_city(server_id, gate_id, index)
+        with city.lock():
+            city.parent.players.remove(session)
+            city.players.add(session)
+            session.local_info["city_name"] = city.name
+        session.local_info["city_id"] = index
+        return city
+
+    def leave_city(self, session):
+        # type: (Session) -> None
+        city = self.get_city(session.local_info["server_id"],
+                             session.local_info["gate_id"],
+                             session.local_info["city_id"])
+        with city.lock():
+            city.parent.players.add(session)
+            city.players.remove(session)
+            if not city.get_population():
+                city.clear_circles()
+        session.local_info["city_id"] = None
+        session.local_info["city_name"] = None
+
+    def layer_detail_search(self, server_type, fields):
+        # TODO: Better document and test this
+        cities = []
+
+        def match_city(city, fields):
+            with city.lock():
+                return all((
+                    field in city.optional_fields
+                    for field in fields
+                ))
+
+        for server in self.get_servers():
+            if server.server_type != server_type:
+                continue
+            for gate in server.gates:
+                if not gate.get_population():
+                    continue
+                cities.extend([
+                    city
+                    for city in gate.cities
+                    if match_city(city, fields)
+                ])
+        return cities

--- a/mh/state_models.py
+++ b/mh/state_models.py
@@ -1,0 +1,585 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# SPDX-FileCopyrightText: Copyright (C) 2025 MH3SP Server Project
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""FMP server state models module.
+
+This module contains ORM-like models to be (de)serialized.
+"""
+
+import time
+
+from threading import RLock
+
+try:
+    from typing import Any, Literal, TYPE_CHECKING  # noqa: F401
+
+    ServerTypeLiteral = Literal[1, 2, 3, 4]
+    LayerStateLiteral = Literal[0, 1, 2]
+
+    if TYPE_CHECKING:
+        # FIXME: Session.deserialize introduces cyclic import
+        from mh.session import Session
+except (ImportError, TypeError):
+    pass
+
+
+RESERVE_DC_TIMEOUT = 40.0
+
+
+class ServerType:
+    OPEN = 1
+    ROOKIE = 2
+    EXPERT = 3
+    RECRUITING = 4
+
+
+class LayerState:
+    JOINABLE = 0
+    EMPTY = 1
+    FULL = 2
+
+
+class Lockable(object):
+    def __init__(self):
+        self._lock = RLock()
+
+    def lock(self):
+        return self
+
+    def __enter__(self):
+        # Returns True if lock was acquired, False otherwise
+        return self._lock.acquire()
+
+    def __exit__(self, *args):
+        # type: (Any) -> None
+        self._lock.release()
+
+
+class Players(Lockable):
+    """Helper class to help retain player IDs."""
+    def __init__(self, capacity):
+        # type: (int) -> None
+        assert capacity > 0, "Collection capacity can't be zero"
+
+        self.slots = [
+            None for _ in range(capacity)
+        ]  # type: list[None | Session]
+        self.used = 0
+        super(Players, self).__init__()
+
+    def get_used_count(self):
+        # type: () -> int
+        return self.used
+
+    def get_capacity(self):
+        # type: () -> int
+        return len(self.slots)
+
+    def add(self, item):
+        # type: (Session) -> int
+        with self.lock():
+            if self.used >= len(self.slots):
+                return -1
+
+            item_index = self.index(item)
+            if item_index != -1:
+                return item_index
+
+            for i, v in enumerate(self.slots):
+                if v is not None:
+                    continue
+
+                self.slots[i] = item
+                self.used += 1
+                return i
+
+            return -1
+
+    def remove(self, item):
+        # type: (Session | int) -> bool
+        assert item is not None, "Item != None"
+
+        with self.lock():
+            if self.used < 1:
+                return False
+
+            if isinstance(item, int):
+                if item >= self.get_capacity():
+                    return False
+
+                self.slots[item] = None
+                self.used -= 1
+                return True
+
+            for i, v in enumerate(self.slots):
+                if v != item:
+                    continue
+
+                self.slots[i] = None
+                self.used -= 1
+                return True
+
+            return False
+
+    def index(self, item):
+        # type: (Session) -> int
+        assert item is not None, "Item != None"
+
+        for i, v in enumerate(self.slots):
+            if v == item:
+                return i
+
+        return -1
+
+    def clear(self):
+        # type: () -> None
+        with self.lock():
+            for i in range(self.get_capacity()):
+                self.slots[i] = None
+
+    def find_first(self, **kwargs):
+        # type: (Any) -> None | Session
+        if self.used < 1:
+            return None
+
+        for p in self.slots:
+            if p is None:
+                continue
+
+            for k, v in kwargs.items():
+                if getattr(p, k) != v:
+                    break
+            else:
+                return p
+
+        return None
+
+    def find_by_capcom_id(self, capcom_id):
+        # type: (str) -> None | Session
+        return self.find_first(capcom_id=capcom_id)
+
+    def __len__(self):
+        return self.used
+
+    def __iter__(self):
+        if self.used < 1:
+            return
+
+        for i, v in enumerate(self.slots):
+            if v is None:
+                continue
+
+            yield i, v
+
+    def serialize(self):
+        # type: () -> dict[str, Any]
+        if not self.used:
+            return {"capacity": len(self.slots)}
+        return {
+            "slots": [
+                (p.serialize()
+                 if p is not None
+                 else None)
+                for p in self.slots
+            ],
+            "used": self.used
+        }
+
+    @staticmethod
+    def deserialize(obj, parent):
+        # type: (dict[str, Any], None) -> Players
+        if "used" not in obj.keys():
+            return Players(obj["capacity"])
+
+        from mh.session import Session  # avoid cyclic import
+
+        players = Players(len(obj["slots"]))
+        players.slots = [
+            (Session.deserialize(p)
+             if p is not None
+             else None)
+            for p in obj["slots"]
+        ]
+        players.used = obj["used"]
+        return players
+
+
+class Circle(Lockable):
+    def __init__(self, parent):
+        # type: (City) -> None
+        self.parent = parent
+        self.leader = None  # type: None | Session
+        self.players = Players(4)
+        self.departed = False
+        self.quest_id = 0
+        self.embarked = False  # FIXME: Seems never used
+        self.password = None
+        self.remarks = None
+
+        self.unk_byte_0x0e = 0
+        super(Circle, self).__init__()
+
+    def get_population(self):
+        # type: () -> int
+        return len(self.players)
+
+    def get_capacity(self):
+        # type: () -> int
+        return self.players.get_capacity()
+
+    def is_full(self):
+        # type: () -> bool
+        return self.get_population() == self.get_capacity()
+
+    def is_empty(self):
+        # type: () -> bool
+        return self.leader is None
+
+    def is_joinable(self):
+        # type: () -> bool
+        return not self.departed and not self.is_full()
+
+    def has_password(self):
+        # type: () -> bool
+        return self.password is not None
+
+    def reset_players(self, capacity):
+        # type: (int) -> None
+        with self.lock():
+            self.players = Players(capacity)
+
+    def reset(self):
+        # type: () -> None
+        with self.lock():
+            self.leader = None
+            self.reset_players(4)
+            self.departed = False
+            self.quest_id = 0
+            self.embarked = False
+            self.password = None
+            self.remarks = None
+
+            self.unk_byte_0x0e = 0
+
+    def serialize(self):
+        # type: () -> dict[str, Any]
+        players = self.players.serialize()
+        if "used" not in players.keys():
+            return {}
+        return {
+            "parent": None,
+            "leader":
+                self.leader.serialize()
+                if self.leader is not None
+                else None,
+            "players": players,
+            "departed": self.departed,
+            "quest_id": self.quest_id,
+            "embarked": self.embarked,
+            "password": self.password,
+            "remarks": self.remarks,
+            "unk_byte_0x0e": self.unk_byte_0x0e
+        }
+
+    @staticmethod
+    def deserialize(obj, parent):
+        # type: (dict[str, Any], City) -> Circle
+        circle = Circle(parent)
+        if not obj.keys():
+            return circle
+
+        from mh.session import Session  # avoid cyclic import
+
+        circle.leader = \
+            Session.deserialize(obj["leader"]) \
+            if obj["leader"] is not None \
+            else None
+        # TODO: Players class doesn't have "parent" member variable
+        circle.players = Players.deserialize(obj["players"], circle)
+        circle.departed = obj["departed"]
+        circle.quest_id = obj["quest_id"]
+        circle.embarked = obj["embarked"]
+        circle.password = obj["password"]
+        circle.remarks = obj["remarks"]
+        circle.unk_byte_0x0e = obj["unk_byte_0x0e"]
+        return circle
+
+
+class City(Lockable):
+    LAYER_DEPTH = 3
+
+    def __init__(self, name, parent):
+        # type: (str, Gate) -> None
+        self.name = name
+        self.parent = parent
+        self.state = LayerState.EMPTY
+        self.players = Players(4)
+        self.optional_fields = []
+        self.leader = None
+        self.reserved = None
+        self.circles = [
+            # One circle per player
+            Circle(self) for _ in range(self.get_capacity())
+            # NB: Might not work on the Japanese version, IIRC the limit is 5
+        ]
+        super(City, self).__init__()
+
+    def get_population(self):
+        # type: () -> int
+        return len(self.players)
+
+    def in_quest_players(self):
+        # type: () -> int
+        return sum(p.is_in_quest() for _, p in self.players)
+
+    def get_capacity(self):
+        # type: () -> int
+        return self.players.get_capacity()
+
+    def get_state(self):
+        # type: () -> LayerStateLiteral
+        # FIXME: The following part was removed v
+        if self.reserved:
+            return LayerState.FULL
+        # TODO: ^ Backport it and make sure that wasn't a mistake
+
+        size = self.get_population()
+        if size == 0:
+            return LayerState.EMPTY
+        elif size < self.get_capacity():
+            return LayerState.JOINABLE
+        else:
+            return LayerState.FULL
+
+    def is_empty(self):
+        # type: () -> bool
+        return self.get_state() == LayerState.EMPTY
+
+    def get_pathname(self):
+        # type: () -> str
+        pathname = self.name  # type: str
+        it = self.parent
+        # FIXME: Some tools don't like type-checking this loop at all
+        while it is not None:  # type: ignore
+            pathname = it.name + "\t" + pathname
+            it = it.parent  # type: Gate | Server | None
+        return pathname
+
+    def get_first_empty_circle(self):
+        # type: () -> tuple[None, None] | tuple[Circle, int]
+        with self.lock():
+            for index, circle in enumerate(self.circles):
+                if circle.is_empty():
+                    return circle, index
+        return None, None
+
+    def get_circle_for(self, leader_session):
+        # type: (Session) -> tuple[None, None] | tuple[Circle, int]
+        with self.lock():
+            for index, circle in enumerate(self.circles):
+                if circle.leader == leader_session:
+                    return circle, index
+        return None, None
+
+    def clear_circles(self):
+        # type: () -> None
+        with self.lock():
+            for circle in self.circles:
+                circle.reset()
+
+    def reserve(self, reserve):
+        # type: (bool) -> None
+        with self.lock():
+            if reserve:
+                self.reserved = time.time()
+            else:
+                self.reserved = None
+
+    def is_reserved(self):
+        # type: () -> bool
+        reserved_time = self.reserved  # type: None | float
+        if reserved_time:
+            return time.time()-reserved_time < RESERVE_DC_TIMEOUT
+        return False
+
+    def get_all_players(self):
+        # type: () -> list[Session]
+        with self.players.lock():
+            return [p for _, p in self.players]
+
+    def serialize(self):
+        # type: () -> dict[str, Any]
+        players = self.players.serialize()
+        if "used" not in players.keys():
+            return {"name": self.name}
+        return {
+            "name": self.name,
+            "parent": None,  # TODO: Why (not) serializing it?
+            "state": self.state,
+            "players": players,
+            "optional_fields": self.optional_fields,
+            "leader":
+                self.leader.serialize()
+                if self.leader is not None
+                else None,
+            "reserved": self.reserved,
+            "circles": [c.serialize() for c in self.circles]
+        }
+
+    @staticmethod
+    def deserialize(obj, parent):
+        # type: (dict[str, Any], Gate) -> City
+        if len(obj.keys()) < 2:
+            return City(obj["name"], None)
+        city = City(
+            str(obj["name"]) if obj["name"] is not None else obj["name"],
+            parent
+        )
+        city.state = obj["state"]
+        city.players = Players.deserialize(obj["players"], parent)
+        city.optional_fields = obj["optional_fields"]
+        city.leader = \
+            Session.deserialize(obj["leader"]) \
+            if obj["leader"] is not None \
+            else None
+        city.reserved = obj["reserved"]
+        city.circles = [Circle.deserialize(c, city) for c in obj["circles"]]
+        return city
+
+
+class Gate(object):
+    LAYER_DEPTH = 2
+
+    def __init__(self, name, parent, city_count=40, player_capacity=100):
+        # type: (str, Server, int, int) -> None
+        self.name = name
+        self.parent = parent
+        self.state = LayerState.EMPTY
+        self.cities = [
+            City("City{}".format(i), self)
+            for i in range(1, city_count+1)
+        ]
+        self.players = Players(player_capacity)
+        self.optional_fields = []
+
+    def get_population(self):
+        # type: () -> int
+        return len(self.players) + sum((
+            city.get_population()
+            for city in self.cities
+        ))
+
+    def get_capacity(self):
+        # type: () -> int
+        return self.players.get_capacity()
+
+    def get_state(self):
+        # type: () -> LayerStateLiteral
+        size = self.get_population()
+        if size == 0:
+            return LayerState.EMPTY
+        elif size < self.get_capacity():
+            return LayerState.JOINABLE
+        else:
+            return LayerState.FULL
+
+    def get_all_players(self):
+        # type: () -> list[Session]
+        # TODO: Backport its use, e.g. in cache
+        players = [p for _, p in self.players]
+        for city in self.cities:
+            players += city.get_all_players()
+        return players
+
+    def serialize(self):
+        # type: () -> dict[str, Any]
+        return {
+            "name": self.name,
+            "parent": None,
+            "state": self.state,
+            "cities": [c.serialize() for c in self.cities],
+            "players": self.players.serialize(),
+            "optional_fields": self.optional_fields
+        }
+
+    @staticmethod
+    def deserialize(obj, parent):
+        # type: (dict[str, Any], Server) -> Gate
+        gate = Gate(
+            str(obj["name"]) if obj["name"] is not None else obj["name"],
+            parent
+        )
+        gate.state = obj["state"]
+        gate.cities = [City.deserialize(c, gate) for c in obj["cities"]]
+        gate.players = Players.deserialize(obj["players"], gate)
+        gate.optional_fields = obj["optional_fields"]
+        return gate
+
+
+class Server(object):
+    LAYER_DEPTH = 1
+
+    def __init__(self, name, server_type, gate_count=40, capacity=2000,
+                 addr=None, port=None):
+        # type: (str, ServerTypeLiteral, int, int, None | str, None | int) -> None  # noqa: E501
+        # TODO: Backport the constructor change if needed
+        self.name = name
+        self.parent = None
+        self.server_type = server_type
+        # Public IP address
+        self.addr = addr  # type: None | str
+        self.port = port  # type: None | int
+        self.gates = [
+            Gate("City Gate{}".format(i), self)
+            for i in range(1, gate_count+1)
+        ]
+        self.players = Players(capacity)
+
+    def get_population(self):
+        # type: () -> int
+        return len(self.players) + sum((
+            gate.get_population() for gate in self.gates
+        ))
+
+    def get_capacity(self):
+        # type: () -> int
+        return self.players.get_capacity()
+
+    def get_all_players(self):
+        # type: () -> list[Session]
+        # TODO: Backport its use, e.g. in cache
+        players = [p for _, p in self.players]
+        for gate in self.gates:
+            players = players + gate.get_all_players()
+        return players
+
+    def serialize(self):
+        # type: () -> dict[str, Any]
+        return {
+            "name": self.name,
+            "parent": self.parent,
+            "server_type": self.server_type,
+            "addr": self.addr,
+            "port": self.port,
+            "gates": [g.serialize() for g in self.gates],
+            "players": self.players.serialize()
+        }
+
+    @staticmethod
+    def deserialize(obj):
+        # type: (dict[str, Any]) -> Server
+        server = Server(
+            str(obj["name"]) if obj["name"] is not None
+            else obj["name"],
+            int(obj["server_type"]) if obj["server_type"]
+            else obj["server_type"],
+            addr=str(obj["addr"]) if obj["addr"] is not None
+            else obj["addr"],
+            port=int(obj["port"]) if obj["port"] is not None
+            else obj["port"]
+        )
+        server.parent = obj["parent"]
+        server.gates = [Gate.deserialize(g, server) for g in obj["gates"]]
+        server.players = Players.deserialize(obj["players"], server)
+        return server


### PR DESCRIPTION
This PR moves FMP state to its own class and introduces some other changes:
 - city.is_empty method added
 - assert_fields when searching cities fixed

I tried to introduce as much changes as possible without breaking the current implementation (which is done by this ugly workaround in FMP server constructor). The rest will be done with the central/cache server introduction.